### PR TITLE
docs : refonte et ajout des pages de documentation Doxygen

### DIFF
--- a/docs/doxygen/pages/engine.md
+++ b/docs/doxygen/pages/engine.md
@@ -1,157 +1,209 @@
-@page engine Engine — Moteur de l'application
+@page page_engine Engine Core
 
 @tableofcontents
 
 ---
 
-# Core — Cœur applicatif {#core}
+## Vue d'ensemble {#engine_overview}
 
-Gestion des composants fondamentaux et de la logique applicative transverse.
+**Engine Core** regroupe les services **transversaux** utilisés par tous les
+autres modules. Il ne contient aucune logique métier ferroviaire — seulement
+des briques d'infrastructure réutilisables.
 
-| Classe | Rôle |
-|--------|------|
-| Application | Cycle de vie Win32 (enregistrement de classe, boucle de messages) |
-| Logger | Journalisation structurée (INFO / DEBUG / WARNING / ERROR / FAILURE) |
-| @ref TopologyData | Conteneur `std::unique_ptr<StraightBlock>` + `std::unique_ptr<SwitchBlock>` + index de lookup |
-| @ref TopologyRepository | Singleton (Meyers). Accès global à @ref TopologyData via `TopologyRepository::instance().data()` |
-| @ref TopologyRenderer | Classe statique — génère les scripts JS d'injection pour le WebView Leaflet |
-
-## TopologyData {#data}
-
-> **Pourquoi `std::unique_ptr` ?**
-> Les blocs sont polymorphes (`Element*`). Le stockage par valeur entraînerait
-> du slicing et interdirait le déplacement. Le stockage par `std::unique_ptr` garantit :
-> - polymorphisme correct (destructeur virtuel respecté),
-> - propriété exclusive et cycle de vie déterministe,
-> - interdiction de copie accidentelle.
-
-@ref TopologyData expose deux index construits en fin de pipeline via @ref TopologyData::buildIndex() "buildIndex()" :
-
-| Index | Type | Usage |
-|-------|------|-------|
-| `TopologyData::switchIndex` | `std::unordered_map<string, SwitchBlock*>` | Lookup O(1) par ID |
-| `TopologyData::straightIndex` | `std::unordered_map<string, StraightBlock*>` | Lookup O(1) par ID |
-
-> @ref TopologyData::buildIndex() "buildIndex()" doit être appelé après que toutes les adresses sont stables.
-> @ref TopologyData::clear() "clear()" vide également les index.
-
-## TopologyRenderer {#renderer}
-
-@ref TopologyRenderer est une classe statique qui :
-- Sérialise @ref StraightBlock → feature GeoJSON `LineString`
-- Sérialise @ref SwitchBlock → feature GeoJSON `Point`
-- Génère les scripts JavaScript d'injection pour le WebView Leaflet
-- Met à jour le rendu d'un switch et de ses partenaires via @ref TopologyRenderer::updateSwitchBlocks() "updateSwitchBlocks(sw)"
-
-| Méthode | Rôle |
-|---------|------|
-| @ref TopologyRenderer::renderAllStraightBlocks() "renderAllStraightBlocks()" | Efface et redessine tous les @ref StraightBlock |
-| @ref TopologyRenderer::renderAllSwitchBranches() "renderAllSwitchBranches()" | Efface et redessine toutes les branches de switch |
-| @ref TopologyRenderer::renderAllSwitchBlocksJunctions() "renderAllSwitchBlocksJunctions()" | Efface et redessine tous les marqueurs de jonction |
-| @ref TopologyRenderer::updateSwitchBlocks() "updateSwitchBlocks()" | Met à jour visuellement un switch et ses partenaires double |
-| @ref TopologyRenderer::exportToFile() "exportToFile()" | Export GeoJSON complet vers un fichier |
+| Sous-module | Dossier | Rôle |
+|-------------|---------|------|
+| @ref engine_logger "Logger" | `Engine/Core/Logger/` | Journalisation à 5 niveaux |
+| @ref engine_config "ParserConfig" | `Engine/Core/Config/` | Paramètres du pipeline |
+| @ref engine_coords "Coordonnées" | `Engine/Core/Coordinates/` | WGS-84 et UTM |
+| @ref engine_topo "Topologie" | `Engine/Core/Topology/` | Repository, rendu |
 
 ---
 
-# HMI — Interface utilisateur {#hmi}
+## Logger {#engine_logger}
 
-Couche graphique Win32 + WebView2.
+### Concept
 
-| Classe | Rôle |
-|--------|------|
-| MainWindow | Fenêtre principale, routage des messages Win32, coordination UI ↔ métier |
-| ProgressBar | Wrapper du contrôle natif `PROGRESS_CLASS` |
-| WebViewPanel | Affichage cartographique Leaflet embarqué via WebView2 |
-| PCCPanel | Panneau PCC superposé togglable (F2 / menu Vue), child window Win32 |
-| @ref TCORenderer | Renderer GDI statique du schéma TCO — consomme @ref PCCGraph |
-| AboutDialog | Boîte de dialogue modale "À propos" |
-| FileOpenDialog | Sélecteur de fichier GeoJSON (GetOpenFileNameA) |
-| FileSaveDialog | Dialogue de sauvegarde GeoJSON (GetSaveFileNameA) |
+@ref Logger fournit un canal de journalisation **par moteur** : chaque instance
+est associée à un nom de moteur (ex. `"GeoParser"`, `"HMI"`) et écrit dans
+`Logs/<nomDuMoteur>.log`. Les traces sont simultanément envoyées à la **sortie
+de débogage Visual Studio** via `OutputDebugStringA`.
 
-## Panneau PCC {#pcc_panel}
+Les écritures sont protégées par un `std::mutex` — le Logger est utilisable
+depuis plusieurs threads sans synchronisation externe.
 
-Le panneau PCC est une `WS_CHILD` window superposée au `WebViewPanel`, togglée via **F2** ou
-le menu **Vue → Panneau PCC**. Il est masqué par défaut et ne perturbe pas la carte Leaflet.
+### Niveaux de sévérité
 
-@ref PCCPanel possède un @ref PCCGraph qu'il reconstruit à chaque chargement GeoJSON via
-@ref PCCGraphBuilder et @ref PCCLayout. Le rendu est délégué à @ref TCORenderer.
-Le logger HMI est partagé par injection de référence depuis `MainWindow`.
+| Niveau | Macro | Utilisation |
+|--------|-------|-------------|
+| `DEBUG` | `LOG_DEBUG` | Valeurs intermédiaires, état interne |
+| `INFO` | `LOG_INFO` | Événements nominaux (fin de phase, résultats) |
+| `WARNING` | `LOG_WARNING` | Anomalie non-bloquante (données douteuses, repli) |
+| `ERROR` | `LOG_ERROR` | Erreur bloquante récupérable |
+| `FAILURE` | `LOG_FAILURE` | Erreur fatale — journalise **puis** lève `std::runtime_error` |
 
-**Séquence d'appel complète :**
+Le niveau minimum de filtrage est configurable via `setMinimumLogLevel()`.
+En production, positionner à `INFO` supprime les traces `DEBUG` sans modifier
+le code.
 
-```
-MainWindow::onParsingSuccess()
-  ├─► m_webViewPanel.executeScript(...)    — rendu Leaflet inchangé
-  └─► m_pccPanel.refresh()
-        ├─► rebuild()
-        │     ├─► build(m_graph, m_logger)
-        │     └─► compute(m_graph, m_logger)
-        └─► InvalidateRect()  →  WM_PAINT
-              └─► draw(hdc, rc, m_graph, m_logger)
-```
-
-**Cycle de vie :**
-
-| Méthode | Déclencheur |
-|---------|-------------|
-| @ref PCCPanel::create() "PCCPanel::create()" | `MainWindow::create()` — après `WebViewPanel::create()` |
-| @ref PCCPanel::toggle() "PCCPanel::toggle()" | F2 ou `IDM_VIEW_PCC` — place le panneau en `HWND_TOP` |
-| @ref PCCPanel::resize() "PCCPanel::resize()" | `MainWindow::onSizeUpdate()` |
-| @ref PCCPanel::refresh() "PCCPanel::refresh()" | `MainWindow::onParsingSuccess()` |
-
-## TCORenderer {#tco}
-
-Classe utilitaire statique. Consomme `const PCCGraph&` — n'accède pas à @ref TopologyRepository.
-
-**Conventions de couleurs (style TCO SNCF) :**
-
-| État | Couleur |
-|------|---------|
-| Fond | Noir `RGB(0,0,0)` |
-| Voie libre (FREE) | Blanc cassé `RGB(220,220,220)` |
-| Voie occupée (OCCUPIED) | Rouge `RGB(220,50,50)` |
-| Voie inactive (INACTIVE) | Gris `RGB(80,80,80)` |
-| Branche normale active | Vert `RGB(0,200,80)` |
-| Branche déviation active | Jaune `RGB(220,200,0)` |
-
-**Projection positions logiques X/Y → pixels :**
-```
-pixelX = marginX + logicalX * cellWidth
-pixelY = centerY - logicalY * cellHeight   (Y inversé)
-```
-
-| Méthode | Rôle |
-|---------|------|
-| @ref TCORenderer::draw() "draw()" | Point d'entrée — fond + arêtes + nœuds |
-| @ref TCORenderer::computeProjection() "computeProjection()" | Calcul bornes X/Y logiques et taille des cellules |
-| @ref TCORenderer::drawEdges() "drawEdges()" | Un segment GDI par @ref PCCEdge, colorisé par rôle et état |
-| @ref TCORenderer::drawNodes() "drawNodes()" | Un disque GDI par @ref PCCNode |
-
-## Binding bidirectionnel Leaflet ↔ C++ {#binding}
-
-**C++ → Leaflet** : `WebViewPanel::executeScript()` injecte des appels JS générés par @ref TopologyRenderer.
-
-**Leaflet → C++** : `window.chrome.webview.postMessage()` → `WebViewPanel::onWebMessageReceived()` → `MainWindow::onWebMessage()`.
+### Format d'une ligne
 
 ```
-Clic sur jonction switch
-  → postMessage({type:"switch_click", id:"sw/0"})
-  → MainWindow::onSwitchClick()         [switchIndex.find() O(1)]
-  → SwitchBlock::toggleActiveBranch()   [+ propagation partenaires]
-  → TopologyRenderer::updateSwitchBlocks()
-  → WebViewPanel::executeScript()
-  → window.switchApplyState()
+[HH:MM:SS] [NIVEAU  ] {NomDeClasse} [NomDeFonction] "Ligne : XX" : Message
 ```
 
-| type | Champs | Handler C++ |
-|--------|--------|-------------|
-| `switch_click` | `id` | `MainWindow::onSwitchClick()` |
+Exemple :
+```
+[14:23:01] [INFO   ] {GeoParser} [parse] "Ligne : 47" : Phase 3 terminée — 1842 segments.
+```
+
+### Macros d'injection
+
+Sur MSVC, `__FUNCTION__` retourne `"NomDeClasse::NomDeFonction"`. Les macros
+`LOG_*` transmettent `__FUNCTION__` et `__LINE__` au Logger, qui extrait
+automatiquement le nom de classe et le nom de méthode pour les inclure dans
+chaque ligne.
+
+```cpp
+// Utilisation type :
+LOG_INFO(m_logger,    "Fichier chargé : " + filePath);
+LOG_DEBUG(m_logger,   "Nœud " + std::to_string(id) + " créé.");
+LOG_WARNING(m_logger, "Branche trop courte ignorée : " + branchId);
+LOG_ERROR(m_logger,   "Fichier introuvable : " + path);
+LOG_FAILURE(m_logger, "Topologie nulle — arrêt immédiat");
+```
+
+> **`LOG_FAILURE`** journalise le message puis appelle
+> `Logger::triggerFatalCrash()`, qui lève `std::runtime_error`. Il ne
+> retourne jamais — ne pas l'utiliser dans des destructeurs.
+
+### Règle d'unicité
+
+Un fichier de log = une instance de Logger. Les instances ne sont
+**pas copiables** (constructeur de copie supprimé). Partager un logger entre
+plusieurs objets se fait par **référence** ou **pointeur** — jamais par
+valeur.
 
 ---
 
-# Coordonnées {#Coordinates}
+## ParserConfig {#engine_config}
 
-| Classe | Système |
-|--------|---------|
-| @ref CoordinateLatLon | Géographique WGS-84 (latitude, longitude) |
-| @ref CoordinateXY | Métrique UTM (x = est, y = nord) |
+### Paramètres
+
+@ref ParserConfig est un agrégat de paramètres numériques qui gouvernent le
+comportement du @ref page_geoparser "pipeline GeoParser". Tous les champs ont
+des valeurs par défaut compilées.
+
+| Champ | Type | Défaut | Signification |
+|-------|------|--------|---------------|
+| `snapTolerance` | `double` | 1,0 m | Distance de fusion de deux extrémités |
+| `intersectionEpsilon` | `double` | 0,5 m | Tolérance pour les intersections géométriques |
+| `minSwitchAngle` | `double` | 5,0 ° | Angle minimal d'une bifurcation pour être classée SWITCH |
+| `minBranchLength` | `double` | 0,5 m | Longueur minimale d'une branche d'aiguillage |
+| `maxSegmentLength` | `double` | 200,0 m | Longueur au-delà de laquelle un straight est subdivisé |
+| `junctionTrimMargin` | `double` | 3,0 m | Recul des tips CDC depuis la jonction |
+| `switchSideSize` | `double` | 15,0 m | Demi-longueur des stubs CDC |
+| `doubleSwitchRadius` | `double` | 20,0 m | Rayon de détection des aiguilles doubles |
+
+### Persistance INI
+
+@ref ParserConfigIni gère la sérialisation dans un fichier `.ini` simple
+(format `clé=valeur`, un paramètre par ligne). Le chemin par défaut est
+retourné par `ParserConfigIni::defaultPath()`. `load()` retourne les valeurs
+par défaut si le fichier est absent ou illisible ; `save()` crée le fichier
+si nécessaire.
+
+---
+
+## Coordonnées {#engine_coords}
+
+Le projet utilise **deux systèmes de coordonnées** selon le contexte :
+
+### WGS-84 — @ref CoordinateLatLon
+
+Coordonnées géographiques standards (`latitude`, `longitude` en degrés
+décimaux). Utilisées pour :
+- le stockage dans les fichiers GeoJSON source ;
+- les polylignes des @ref StraightBlock et la jonction des @ref SwitchBlock
+  destinées au rendu Leaflet ;
+- les tips CDC pour `TopologyRenderer`.
+
+### UTM zone 30N — @ref CoordinateXY
+
+Coordonnées planes métriques (`x` = est, `y` = nord, en mètres). Utilisées
+pour **tous les calculs métriques** du pipeline (distances, angles, intersections,
+subdivisions). La projection UTM est effectuée par les phases amont du pipeline.
+
+> **Règle de cohabitation :** les deux collections (`pointsWGS84` / `pointsUTM`)
+> dans @ref StraightBlock ont toujours le même nombre de points et les mêmes
+> indices. Opérer toujours sur `UTM` pour les calculs ; utiliser `WGS84`
+> uniquement pour le rendu.
+
+### Haversine
+
+La fonction `haversineDistanceMeters(a, b)` calcule la **distance géodésique**
+entre deux points WGS-84. Elle est utilisée par Phase 7 pour interpoler les
+tips CDC à distance `switchSideSize` de la jonction, et pour calculer
+`StraightBlock::getLengthMeters()`.
+
+---
+
+## Topologie — TopologyRepository {#engine_topo}
+
+### TopologyRepository
+
+Singleton global (`TopologyRepository::instance()`) qui détient le
+@ref TopologyData produit par le @ref page_geoparser "pipeline". Il expose :
+
+- `data()` — référence constante vers les vecteurs de blocs et les index.
+- `load(data)` — transfert par déplacement depuis le pipeline (appelé par
+  `Phase8_RepositoryTransfer::transfer()`).
+- `clear()` — réinitialisation avant un nouveau parsing.
+
+Après `load()`, les adresses des blocs sont **stables** : aucun vecteur
+ne se réalloue. Les pointeurs non-propriétaires distribués par
+@ref PCCGraphBuilder restent valides jusqu'au prochain `clear()`.
+
+### TopologyData
+
+@ref TopologyData est le conteneur central :
+
+```cpp
+struct TopologyData {
+    vector<unique_ptr<StraightBlock>> straights;  // ownership
+    vector<unique_ptr<SwitchBlock>>   switches;   // ownership
+    unordered_map<string, StraightBlock*> straightIndex;  // lookup O(1)
+    unordered_map<string, SwitchBlock*>   switchIndex;    // lookup O(1)
+};
+```
+
+`buildIndex()` construit les maps `id → ptr` après le transfert. Il doit
+être appelé une seule fois, après stabilisation des adresses.
+
+### TopologyRenderer
+
+@ref TopologyRenderer génère les **scripts JavaScript** injectés dans la
+page Leaflet via `WebViewPanel::executeScript()`. Il opère exclusivement sur
+les collections WGS-84 des blocs.
+
+Point d'entrée principal : `renderAllTopology()` — produit en une passe les
+appels `clearStraightBlocks()`, `renderStraightBlock()`, `clearSwitchBranches()`,
+`renderSwitchBranches()`, `clearSwitches()`, `renderSwitch()`.
+
+`updateSwitchBlocks(sw)` produit les appels `switchApplyState()` pour mettre
+à jour visuellement un aiguillage après `toggleActiveBranch()`.
+
+---
+
+## Références croisées {#engine_refs}
+
+| Classe | Fichier | Rôle |
+|--------|---------|------|
+| @ref Logger | `Engine/Core/Logger/Logger.h` | Journalisation multi-niveaux |
+| @ref LogLevel | `Engine/Core/Logger/Logger.h` | Enum de sévérité |
+| @ref ParserConfig | `Engine/Core/Config/ParserConfig.h` | Paramètres numériques |
+| @ref ParserConfigIni | `Engine/Core/Config/ParserConfigIni.h` | Persistance INI |
+| @ref CoordinateLatLon | `Engine/Core/Coordinates/CoordinateLatLon.h` | WGS-84 |
+| @ref CoordinateXY | `Engine/Core/Coordinates/CoordinateXY.h` | UTM (x,y mètres) |
+| @ref TopologyRepository | `Engine/Core/Topology/TopologyRepository.h` | Singleton détenteur |
+| @ref TopologyData | `Engine/Core/Topology/TopologyData.h` | Vecteurs + index |
+| @ref TopologyRenderer | `Engine/Core/Topology/TopologyRenderer.h` | Rendu Leaflet JS |

--- a/docs/doxygen/pages/geoparser.md
+++ b/docs/doxygen/pages/geoparser.md
@@ -1,551 +1,295 @@
-@page geoparser GeoParser — Pipeline
+@page page_geoparser Pipeline GeoParser v2
 
 @tableofcontents
 
 ---
 
-# GeoParser {#geoparser}
+## Vue d'ensemble {#geo_overview}
 
-Pipeline complet de transformation **GeoJSON → modèle ferroviaire**.
+Le **pipeline GeoParser v2** transforme un fichier GeoJSON contenant la géométrie
+brute d'un réseau ferroviaire (polylignes OSM) en une topologie structurée de
+blocs (@ref StraightBlock, @ref SwitchBlock) prête à être consommée par le
+@ref page_pcc "module PCC" et le rendu WebView.
 
-## Architecture du pipeline {#pipeline_arch}
+Le pipeline est **séquentiel** et se déroule en 8 phases numérotées, chacune
+encapsulée dans une classe statique `PhaseN_Xxx`. Les données intermédiaires
+transitent via le @ref PipelineContext, qui est l'unique objet partagé entre
+les phases.
+
+### Ordre d'exécution (immuable)
 
 ```
-GeoParsingTask (thread async)
-  └─► GeoParser (orchestrateur)
-        ├─► PipelineContext  (transporteur inter-phases)
-        ├─► ParserConfig     (paramètres immuables pendant le parsing)
-        └─► Phase1..8        (chacune : run(ctx, config, logger))
+Phase1  → Phase2  → Phase3  → Phase4  → Phase5  → Phase6
+   GeoLoader  Intersector  Splitter  TopoBuilder  Classifier  Extractor
+
+Phase8::resolve()  →  Phase7  →  Phase8::transfer()
+  ResolvePtrs         SwitchProc    TransferToRepo
 ```
 
-## Phases {#pipeline}
-
-| Ordre | Phase | Classe | Input → Output |
-|-------|-------|--------|----------------|
-| 1 | Chargement GeoJSON | Phase1_GeoLoader | fichier → `RawNetwork` (WGS84 + UTM) |
-| 2 | Intersections géométriques | Phase2_GeometricIntersector | `RawNetwork` → `IntersectionData` (Cramer + grid binning) |
-| 3 | Découpe des segments | Phase3_NetworkSplitter | `RawNetwork` + `IntersectionData` → `SplitNetwork` |
-| 4 | Graphe planaire | Phase4_TopologyBuilder | `SplitNetwork` → `TopologyGraph` (Union-Find + snap) |
-| 5 | Classification des nœuds | Phase5_SwitchClassifier | `TopologyGraph` → `ClassifiedNodes` (degré + angle) |
-| 6 | Extraction des blocs | Phase6_BlockExtractor | `ClassifiedNodes` → `BlockSet` (DFS + subdivision) |
-| 8a | Résolution des pointeurs | Phase8_RepositoryTransfer | `BlockSet` → pointeurs inter-blocs résolus |
-| 7 | Traitement des switches | Phase7_SwitchProcessor | `BlockSet` → orientation + doubles + crossovers + tips |
-| 8b | Transfert final | Phase8_RepositoryTransfer | `BlockSet` → TopologyRepository |
-
-> **Ordre d'exécution réel dans GeoParser::parse() "GeoParser::parse()" :**
-> Phase1 → 2 → 3 → 4 → 5 → 6 → 8a::resolve → 7::run → 8b::transfer.
->
-> Phase 7 nécessite les pointeurs résolus par 8a (orientation géométrique
-> et détection crossovers utilisent `getRootBlock()` / `getNormalBlock()` / `getDeviationBlock()`).
-> Phase 8b doit être la dernière — état final de TopologyRepository.
-
-## Libération mémoire inter-phases {#memory}
-
-| Libéré après | Structure | Raison |
-|--------------|-----------|--------|
-| Phase 3 | `RawNetwork`, `IntersectionData` | Consommées intégralement par Phase 3 |
-| Phase 6 | `TopologyGraph`, `ClassifiedNodes`, `SplitNetwork` | Phase 5 utilise encore `SplitNetwork`; Phase 6 est la dernière à en avoir besoin |
-| Phase 8b | `BlockSet` | Transféré vers `TopologyRepository` via `std::move` |
-
-> `SplitNetwork` est libéré en Phase 6 (et non Phase 4) parce que
-> Phase5_SwitchClassifier l'utilise pour affiner les vecteurs d'angle.
-
-## Tâche asynchrone {#task}
-
-GeoParsingTask lance GeoParser dans un thread détaché.
-Communication vers l'UI via `PostMessage` :
-
-| Message | wParam | lParam | Signification |
-|---------|--------|--------|---------------|
-| `WM_PROGRESS_UPDATE` | 0-100 | `std::wstring*` label (à libérer) | Avancement |
-| `WM_PARSING_SUCCESS` | — | — | Parsing terminé |
-| `WM_PARSING_ERROR` | — | `std::wstring*` message (à libérer) | Échec |
-| `WM_PARSING_CANCELLED` | — | — | Annulation propre |
-
-**Annulation :** GeoParsingTask::cancel() "GeoParsingTask::cancel()" positionne un `shared_ptr<atomic<bool>>`
-partagé avec GeoParser. Vérifié entre chaque phase via GeoParser::checkCancel() "GeoParser::checkCancel()"
-→ lève GeoParser::CancelledException "GeoParser::CancelledException".
-
-## Structures de données du pipeline {#pipeline_data}
-
-| Struct | Phase productrice | Contenu |
-|--------|-------------------|---------|
-| `RawNetwork` | Phase 1 | Polylignes WGS84 + UTM brutes |
-| `IntersectionData` | Phase 2 | Points d'intersection + grille spatiale |
-| `SplitNetwork` | Phase 3 | Segments atomiques sans intersection interne |
-| `TopologyGraph` | Phase 4 | Graphe planaire nœuds + arêtes + adjacence |
-| `ClassifiedNodes` | Phase 5 | `NodeClass` par nœud |
-| `BlockSet` | Phase 6 | `unique_ptr<StraightBlock>` + `unique_ptr<SwitchBlock>` + index lookup |
+> **Invariant critique :** `Phase8::resolve()` doit précéder `Phase7`
+> (le processeur d'aiguillages a besoin des pointeurs résolus pour le recul
+> des tips CDC). `Phase8::transfer()` doit toujours être **en dernier**.
 
 ---
 
-# Architecture des fichiers {#gp_files}
+## PipelineContext {#geo_context}
+
+@ref PipelineContext est le sac de données partagé entre toutes les phases.
+Il évolue à chaque phase : les champs produits par une phase deviennent des
+entrées de la suivante. Certains champs sont explicitement libérés par la phase
+qui les a consommés (ex. `topoGraph`, `classifiedNodes`, `splitNetwork` sont
+effacés en fin de Phase 6 pour libérer la mémoire).
+
+Structure simplifiée :
 
 ```
-Engine/Core/Config/
-  ├── ParserConfig.h              POD pur — 8 paramètres
-  └── ParserConfigIni.h/.cpp      load/save .ini via SimpleIni
-
-External/SimpleIni/
-  └── SimpleIni.h                 header-only (github.com/brofield/simpleini)
-
-Engine/HMI/Dialogs/
-  └── ParserSettingsDialog.h/.cpp Dialogue modal Win32
-
-Config/
-  └── parser_settings.ini         Créé au premier lancement
-
-Modules/GeoParser/
-  ├── GeoParser.h/.cpp            Orchestrateur — possède PipelineContext
-  ├── GeoParsingTask.h/.cpp       Thread async
-  └── Pipeline/
-      ├── PipelineContext.h       Conteneur central inter-phases
-      ├── RawNetwork.h            Données Phase 1
-      ├── IntersectionMap.h       Données Phase 2
-      ├── SplitNetwork.h          Données Phase 3
-      ├── TopologyGraph.h         Données Phase 4
-      ├── ClassifiedNodes.h       Données Phase 5
-      ├── BlockSet.h              Données Phases 6-8
-      ├── Phase1_GeoLoader.h/.cpp
-      ├── Phase2_GeometricIntersector.h/.cpp
-      ├── Phase3_NetworkSplitter.h/.cpp
-      ├── Phase4_TopologyBuilder.h/.cpp
-      ├── Phase5_SwitchClassifier.h/.cpp
-      ├── Phase6_BlockExtractor.h/.cpp
-      ├── Phase7_SwitchProcessor.h/.cpp    
-      └── Phase8_RepositoryTransfer.h/.cpp
+PipelineContext
+├── filePath         : string           (Phase 1 → lecture)
+├── rawFeatures      : vector<GeoFeature>  (Phase 1 → sortie)
+├── splitNetwork     : SplitNetwork     (Phase 3 → sortie, libéré Phase 6)
+├── topoGraph        : TopoGraph        (Phase 4 → sortie, libéré Phase 6)
+├── classifiedNodes  : ClassifiedNodes  (Phase 5 → sortie, libéré Phase 6)
+└── blocks           : BlockSet         (Phase 6 → sortie, Phase 8 → transfert)
 ```
 
 ---
 
-# ParserConfig — Paramètres {#gp_config}
+## Phases détaillées {#geo_phases}
 
-`ParserConfig` est un **struct POD pur** — transporteur de paramètres sans logique métier.
-`ParserConfigIni` gère uniquement la persistence `.ini` via SimpleIni.
+### Phase 1 — GeoLoader {#geo_p1}
 
-```cpp
-struct ParserConfig
-{
-    double snapTolerance       = 3.0;     // [Topology]
-    double maxSegmentLength    = 1000.0;  // [Topology]
-    double intersectionEpsilon = 1.5;     // [Intersection]
-    double minSwitchAngle      = 15.0;    // [Switch]
-    double junctionTrimMargin  = 25.0;    // [Switch]
-    double doubleSwitchRadius  = 50.0;    // [Switch]
-    double switchSideSize      = 15.0;    // [Switch]  ← nouveau
-    double minBranchLength     = 100.0;   // [CDC]
-};
-```
+**Classe :** @ref Phase1_GeoLoader
 
-| Paramètre | Défaut | Section .ini | Description |
-|-----------|--------|--------------|-------------|
-| `snapTolerance` | `3.0 m` | `[Topology]` | Rayon de fusion des nœuds proches |
-| `maxSegmentLength` | `1000.0 m` | `[Topology]` | Longueur maximale d'un StraightBlock avant subdivision |
-| `intersectionEpsilon` | `1.5 m` | `[Intersection]` | Tolérance de détection d'intersection géométrique |
-| `minSwitchAngle` | `15.0°` | `[Switch]` | Angle minimal pour identifier une bifurcation réelle |
-| `junctionTrimMargin` | `25.0 m` | `[Switch]` | Marge de recadrage visuel aux jonctions |
-| `doubleSwitchRadius` | `50.0 m` | `[Switch]` | Distance maximale entre deux switches pour former une double aiguille |
-| `switchSideSize` | `15.0 m` | `[Switch]` | Longueur des branches CDC (tips root/normal/deviation) depuis la jonction |
-| `minBranchLength` | `100.0 m` | `[CDC]` | Longueur minimale de branche pour la validation CDC |
+Charge le fichier GeoJSON depuis le disque et désérialise chaque `Feature`
+de type `LineString` en une liste de `GeoFeature` (polyligne WGS-84).
 
-**Séparation POD / persistance (SRP) :**
+Les features non-linéaires (points, polygones) sont ignorées avec un warning.
 
-```
-ParserConfig     — décrit les paramètres                  (aucune dépendance)
-ParserConfigIni  — lit/écrit parser_settings.ini          (dépend de SimpleIni)
-```
-
-`GeoParser` reçoit `ParserConfig` **par valeur** — snapshot immuable pendant toute la durée d'un parsing, thread-safe par construction.
+**Entrées :** `ctx.filePath`
+**Sorties :** `ctx.rawFeatures`
 
 ---
 
-# PipelineContext — Transporteur inter-phases {#gp_context}
+### Phase 2 — GeometricIntersector {#geo_p2}
 
-`PipelineContext` est le **seul** objet partagé entre toutes les phases.
+**Classe :** @ref Phase2_GeometricIntersector
 
-```
-Phase1  écrit  ctx.rawNetwork
-Phase2  lit    ctx.rawNetwork      écrit  ctx.intersections
-Phase3  lit    ctx.intersections   écrit  ctx.splitNetwork    → rawNetwork.clear(), intersections.clear()
-Phase4  lit    ctx.splitNetwork    écrit  ctx.topoGraph
-Phase5  lit    ctx.topoGraph       écrit  ctx.classifiedNodes (lit aussi ctx.splitNetwork)
-Phase6  lit    ctx.topoGraph
-               ctx.classifiedNodes
-               ctx.splitNetwork    écrit  ctx.blocks          → topoGraph.clear(), classifiedNodes.clear(), splitNetwork.clear()
-Phase8a lit    ctx.blocks          (résolution pointeurs)
-Phase7  lit    ctx.blocks          (modifie orientations, absorbe doubles, calcule tips)
-Phase8b lit    ctx.blocks          → TopologyRepository       → blocks.clear()
-```
+Détecte et matérialise les **intersections géométriques** entre segments
+de polylignes distincts qui se croisent sans partager de nœud commun dans
+le GeoJSON source.
 
-**PhaseStats — instrumentation intégrée :**
+Pour chaque paire de segments, un test d'intersection 2D (sur coordonnées UTM)
+est effectué. Si l'intersection tombe dans le segment (hors extrémités à
+`intersectionEpsilon` près), un **nouveau point** est inséré dans les deux
+polylignes à la position exacte de croisement.
 
-Chaque phase enregistre sa durée et son compte d'éléments dans `ctx.stats`.
-GeoParser::logPerformanceSummary() "GeoParser::logPerformanceSummary()" produit le tableau de performance en fin de pipeline.
+**Paramètre clé :** `config.intersectionEpsilon`
+
+**Entrées :** `ctx.rawFeatures`
+**Sorties :** `ctx.rawFeatures` (modifiées in place)
 
 ---
 
-# GeoParser — Orchestrateur {#gp_orchestrator}
+### Phase 3 — NetworkSplitter {#geo_p3}
 
-GeoParser possède `PipelineContext` et `ParserConfig`.
-Il enchaîne les phases et reporte la progression via callback.
+**Classe :** @ref Phase3_NetworkSplitter
 
-| Méthode | Rôle |
-|---------|------|
-| GeoParser::GeoParser() "GeoParser(config, logger, onProgress)" | Construction — snapshot de config |
-| GeoParser::parse() "parse(filePath)" | Pipeline complet — phases 1 à 8 |
-| GeoParser::reportProgress() "reportProgress(int)" | Callback UI + log de la dernière phase |
-| GeoParser::logPerformanceSummary() "logPerformanceSummary()" | Tableau de performance final |
+**Fusionne** les extrémités proches (`snapTolerance`) en un nœud unique, puis
+**découpe** les polylignes aux points de fusion pour obtenir un réseau
+d'**segments atomiques** (un segment = deux extrémités, pas de nœud interne).
 
----
+À l'issue de cette phase, tout point présent à l'intérieur d'une polyligne
+est forcément une extrémité d'un autre segment.
 
-# Phases du pipeline {#gp_phases}
+**Paramètre clé :** `config.snapTolerance`
 
-## Phase 1 — GeoLoader {#gp_phase1}
-
-**Fichiers :** `Phase1_GeoLoader.h/.cpp` · `RawNetwork.h`
-
-Charge le fichier GeoJSON, projette les coordonnées WGS-84 en UTM et produit le `RawNetwork`.
-
-| Étape interne | Description |
-|---------------|-------------|
-| Lecture JSON | `nlohmann::json::parse()` — lève `std::runtime_error` si GeoJSON invalide |
-| Filtrage | Seules les features `LineString` sont retenues |
-| Détection zone UTM | Calculée depuis le premier point du premier segment |
-| Projection | WGS-84 → UTM (formules ellipsoïde WGS-84 complètes, Phase1_GeoLoader::project) |
-
-**Sortie :** `ctx.rawNetwork` — polylignes avec points WGS-84 et UTM synchronisés.
+**Entrées :** `ctx.rawFeatures`
+**Sorties :** `ctx.splitNetwork` (collection de `AtomicSegment`)
 
 ---
 
-## Phase 2 — GeometricIntersector {#gp_phase2}
+### Phase 4 — TopologyBuilder {#geo_p4}
 
-**Fichiers :** `Phase2_GeometricIntersector.h/.cpp` · `IntersectionMap.h`
+**Classe :** @ref Phase4_TopologyBuilder
 
-Calcule tous les points d'intersection géométrique entre segments du `RawNetwork`.
+Construit le **graphe topologique** (`TopoGraph`) à partir du réseau atomique.
+Chaque nœud du graphe correspond à une extrémité physique unique (après snap) ;
+chaque arête correspond à un `AtomicSegment`.
 
-| Mécanisme | Description |
-|-----------|-------------|
-| Algorithme | Cramer (résolution système linéaire 2×2) |
-| Tolérance | `config.intersectionEpsilon` — évite les faux positifs sur flottants |
-| Optimisation | Spatial grid binning : O(n·k) — seuls les segments de cellules adjacentes sont testés |
+Le graphe est non-orienté : les adjacences sont bidirectionnelles.
 
-**Sortie :** `ctx.intersections` — `map<SegmentId, vector<IntersectionPoint>>`
-
-### Algorithme de Cramer
-
-Deux segments AB et CD se croisent si on peut écrire :
-
-```
-P = A + t * (B - A)    t ∈ [0,1]
-P = C + u * (D - C)    u ∈ [0,1]
-```
-
-En égalisant :
-
-```
-| Bx-Ax   -(Dx-Cx) |   | t |   | Cx-Ax |
-| By-Ay   -(Dy-Cy) | × | u | = | Cy-Ay |
-```
-
-`det == 0` → segments parallèles. Sinon, `t` et `u` résolus par Cramer.
-Les segments se croisent si et seulement si `t ∈ [0,1]` et `u ∈ [0,1]`.
-
-> Référence : https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection
+**Entrées :** `ctx.splitNetwork`
+**Sorties :** `ctx.topoGraph`
 
 ---
 
-## Phase 3 — NetworkSplitter {#gp_phase3}
+### Phase 5 — SwitchClassifier {#geo_p5}
 
-**Fichiers :** `Phase3_NetworkSplitter.h/.cpp` · `SplitNetwork.h`
+**Classe :** @ref Phase5_SwitchClassifier
 
-Découpe les polylignes brutes aux points d'intersection et aux dépassements de `maxSegmentLength`.
+Classifie chaque nœud du graphe en l'une des trois catégories :
 
-| Mécanisme | Description |
-|-----------|-------------|
-| Découpe aux intersections | Tri + dédoublonnage des paramètres `t` par distance curviligne |
-| Filtrage micro-segments | Segments < `2 * intersectionEpsilon` supprimés |
-| Découpe par longueur | Interpolation linéaire UTM aux multiples de `maxSegmentLength` |
-| Libération mémoire | `ctx.rawNetwork.clear()` + `ctx.intersections.clear()` après production |
+| `NodeClass` | Degré | Condition |
+|-------------|-------|-----------|
+| `ENDPOINT` | 1 | Terminus de ligne |
+| `STRAIGHT` | 2 | Nœud de passage — pas d'intersection |
+| `SWITCH` | 3+ | Bifurcation — angle entre branches ≥ `minSwitchAngle` |
 
-**Correction — cohérence `globalIdx` :**
-Les polylignes dégénérées (`pointsUTM.size() < 2`) sont sautées **sans incrémenter**
-`globalIdx`, ce qui maintient la cohérence avec l'index calculé par
-Phase2_GeometricIntersector::globalSegmentIndex() "Phase2::globalSegmentIndex()".
-L'ancienne version incrémentait `globalIdx` dans ce cas, causant un décalage
-qui faisait ignorer des intersections valides.
+Un nœud de degré 3 dont toutes les branches sont colinéaires (angle < seuil)
+est reclassifié en `STRAIGHT` pour éviter de créer un aiguillage fantôme
+sur une légère imperfection géométrique OSM.
 
-**Sortie :** `ctx.splitNetwork` — vecteur d'`AtomicSegment`
+**Paramètres clés :** `config.minSwitchAngle`, `config.minBranchLength`
 
----
-
-## Phase 4 — TopologyBuilder {#gp_phase4}
-
-**Fichiers :** `Phase4_TopologyBuilder.h/.cpp` · `TopologyGraph.h`
-
-Construit le **graphe planaire** depuis les segments atomiques.
-Fusionne les extrémités proches via Union-Find + grid binning.
-
-| Mécanisme | Description |
-|-----------|-------------|
-| Snap | Grid binning — nœuds dans un rayon `snapTolerance` mis en candidats |
-| Union-Find | Fusion des nœuds candidats — path compression + union by rank |
-| Graphe | Nœuds (positions UTM fusionnées) + arêtes (segments) + adjacence |
-
-**Correction :** `throw EXCEPTION_EXECUTE_FAULT` remplacé par
-`throw std::runtime_error(...)` — catchable proprement par les handlers
-standards (`catch (const std::exception&)`) dans `GeoParser::parse()`.
-
-**Note mémoire :** `splitNetwork` n'est **pas** libéré ici (contrairement à l'ancienne
-version). Phase5_SwitchClassifier en a encore besoin pour les vecteurs d'angle.
-
-**Sortie :** `ctx.topoGraph` — graphe planaire nœuds + arêtes UTM
-
-### Union-Find — principe
-
-```
-Éléments : [0, 1, 2, 3, 4]
-parent   : [0, 0, 2, 2, 4]  ← 0 et 1 dans le même ensemble, 2 et 3 aussi
-
-find(3) → parent[3] = 2 → parent[2] = 2 → racine = 2
-unite(1, 3) → parent[0] = 2
-```
-
-Path compression : `parent[x] = find(parent[x])` — aplatit l'arbre récursivement.
-Union by rank : la racine de rang inférieur pointe vers la racine de rang supérieur — évite les arbres dégénérés.
-
-> Référence : https://en.wikipedia.org/wiki/Disjoint-set_data_structure
+**Entrées :** `ctx.topoGraph`
+**Sorties :** `ctx.classifiedNodes`
 
 ---
 
-## Phase 5 — SwitchClassifier {#gp_phase5}
+### Phase 6 — BlockExtractor {#geo_p6}
 
-**Fichiers :** `Phase5_SwitchClassifier.h/.cpp` · `ClassifiedNodes.h`
+**Classe :** @ref Phase6_BlockExtractor
 
-Attribue une `NodeClass` à chaque nœud du graphe planaire en combinant **degré** et **angle**.
+Produit les @ref StraightBlock et @ref SwitchBlock à partir du graphe classifié.
 
-```cpp
-enum class NodeClass
-{
-    TERMINUS,   // degré == 1
-    STRAIGHT,   // degré == 2, angle ≈ 180° (± minSwitchAngle)
-    SWITCH,     // degré == 3, bifurcation géométrique réelle
-    CROSSING,   // degré == 4 — croisement plat, ignoré
-    ISOLATED,   // degré == 0
-    AMBIGUOUS   // autre — WARNING
-};
-```
+#### Extraction des straights
 
-**Correction — suppression de la dépendance `SplitNetwork` :**
-`outVector()` calculait auparavant la direction depuis les points intermédiaires
-du segment atomique (`SplitNetwork`). Il utilise maintenant directement la
-position UTM du nœud opposé dans le graphe — indépendant de `SplitNetwork`,
-et suffisamment précis après découpe par `maxSegmentLength`.
+DFS entre nœuds frontières (classe ≠ `STRAIGHT`). La déduplication repose sur
+les **indices d'arêtes** (`usedEdges`) et non sur la clé de paire de nœuds :
+cette approche permet de créer deux straights distincts entre les mêmes deux
+nœuds frontières dans les configurations **crossover** (voie double).
 
-```cpp
-// Avant (dépendait de SplitNetwork)
-static CoordinateXY outVector(const TopologyGraph&, const SplitNetwork&, size_t, size_t);
+Si la longueur totale UTM du straight assemblé dépasse `maxSegmentLength`,
+il est **subdivisé** en *N* sous-blocs chaînés via `prev`/`next`. Seuls les
+sous-blocs de tête et de queue possèdent des `BlockEndpoint` avec
+`frontierNodeId` valide (≠ `SIZE_MAX`).
 
-// Après (indépendant)
-static CoordinateXY outVector(const TopologyGraph&, size_t nodeId, size_t edgeIdx);
-```
+#### Extraction des switches
 
-**Sortie :** `ctx.classifiedNodes` — `unordered_map<size_t, NodeClass>`
+Un @ref SwitchBlock par nœud `SWITCH`. Pour chaque branche, une traversal
+des nœuds intermédiaires remonte jusqu'au nœud frontière adjacent, puis
+`straightByDirectedPair` (multi-valué) fournit le @ref StraightBlock
+adjacent. Un ensemble `usedStraights` local garantit qu'un même straight
+n'est pas attribué à deux branches du même switch (cas crossover).
 
----
+#### Index produits
 
-## Phase 6 — BlockExtractor {#gp_phase6}
+| Index | Clé | Valeur |
+|-------|-----|--------|
+| `straightsByNode` | `nodeId` | `vector<StraightBlock*>` (multi-valué) |
+| `straightByEndpointPair` | `Cantor(min,max)` | `StraightBlock*` premier depuis A |
+| `straightByDirectedPair` | `from*1e6 + to` | `vector<StraightBlock*>` (multi-valué) |
+| `switchByNode` | `nodeId` | `SwitchBlock*` |
 
-**Fichiers :** `Phase6_BlockExtractor.h/.cpp` · `BlockSet.h`
-
-Transforme le graphe planaire classifié en blocs ferroviaires.
-
-| Mécanisme | Description |
-|-----------|-------------|
-| Nœuds frontières | `SWITCH`, `TERMINUS`, `CROSSING` — délimitent les blocs |
-| Nœuds transparents | `STRAIGHT` — traversés lors du DFS |
-| DFS entre frontières | Parcours itératif — concatène les segments en voie droite |
-| Subdivision | Si longueur > `maxSegmentLength` → N sous-blocs chaînés par `prev/next` |
-| SwitchBlocks | Un bloc par nœud `SWITCH` |
-| Libération | `ctx.topoGraph.clear()`, `ctx.classifiedNodes.clear()`, `ctx.splitNetwork.clear()` |
-
-**Sortie :** `ctx.blocks` — `BlockSet`
-
-### Déduplication — par arêtes (et non par paire de nœuds)
-
-L'ancienne déduplication `processedPairs.insert(pairKey(nodeA, nodeB))` empêchait
-la création de deux straights entre les mêmes switches — cassant les configurations
-**crossover** (voie double). La marque à la place les arêtes utilisées (`usedEdges`) :
-
-```
-Straight créé via startEdge → ... → lastEdge :
-  usedEdges.insert(startEdge)   ← empêche une nouvelle traversal depuis cet arête
-  usedEdges.insert(lastEdge)    ← empêche la traversal inverse B→A
-```
-
-Deux straights empruntant des arêtes de départ distinctes peuvent ainsi coexister.
-
-### Subdivision par longueur cumulée
-
-L'ancienne subdivision découpait par proportion de points (`k * totalPts / N`),
-ce qui produisait des sous-blocs inégaux si les points GeoJSON étaient mal répartis.
-La calcule d'abord les longueurs cumulées :
-
-```cpp
-cumLen[0] = 0
-cumLen[i] = cumLen[i-1] + hypot(pts[i] - pts[i-1])
-totalLen  = cumLen.back()
-```
-
-Puis pour le sous-bloc `k`, cherche le premier point `i` où `cumLen[i] >= k/N * totalLen`.
-Chaque sous-bloc a ainsi une longueur UTM quasi-identique indépendamment de la densité des points.
-
-### Index directionnels dans BlockSet
-
-```
-straightsByNode        : nodeId → vector<StraightBlock*>
-                         Multi-valué (switch adjacent à plusieurs straights)
-
-straightByEndpointPair : Cantor(min(A,B), max(A,B)) → StraightBlock*
-                         Un seul élément — utilisé par rebuildStraightIndex()
-
-straightByDirectedPair : (from * 1'000'000 + to) → vector<StraightBlock*>
-                         Multi-valué pour les crossovers.
-                         directedKey(switchNode, frontier) → sous-bloc adjacent au switch
-                         directedKey(frontier, switchNode) → sous-bloc adjacent au frontier
-```
-
-`extractSwitches` utilise `straightByDirectedPair` pour résoudre les endpoints
-de chaque branche. En cas de crossover (deux straights pour la même clé directionnelle),
-un ensemble `usedStraights` par switch garantit que chaque branche reçoit un straight distinct.
-
-### Chaînage des sous-blocs
-
-Les sous-blocs produits par subdivision sont chaînés immédiatement par `prev/next`
-dans `registerStraight`. Phase8_RepositoryTransfer::resolveStraight() "Phase8::resolveStraight()"
-ne surécrit ces pointeurs que si `neighbourId` est non vide — les endpoints internes
-(avec `frontierNodeId == SIZE_MAX`) ne sont jamais touchés, préservant la chaîne.
+**Libération mémoire :** `topoGraph`, `classifiedNodes`, `splitNetwork` sont
+vidés en fin de phase.
 
 ---
 
-## Phase 7 — SwitchProcessor {#gp_phase7}
+### Phase 8a — RepositoryTransfer::resolve() {#geo_p8a}
 
-**Fichiers :** `Phase7_SwitchProcessor.h/.cpp`
+**Classe :** @ref Phase8_RepositoryTransfer, méthode `resolve()`
 
-Fusion de l'ancien `Phase7_DoubleSwitchDetector` et `Phase8_SwitchOrientator`.
-Les deux classes partageaient les mêmes préconditions (pointeurs résolus par Phase 8a)
-et s'enchaînaient naturellement — leur fusion réduit la surface du pipeline.
+Résout les **pointeurs inter-blocs** en deux passes :
 
-### Sous-phases G → A → B → C → D → E → F
+1. **Passe 1 — StraightBlocks :** Pour chaque endpoint d'un straight avec
+   `frontierNodeId` valide, cherche le voisin dans `switchByNode` ou
+   `straightsByNode` et appelle `setNeighbourPrev/Next`. Les endpoints internes
+   (`frontierNodeId == SIZE_MAX`) sont ignorés — la chaîne prev/next posée
+   par Phase 6 est préservée.
 
-| Sous-phase | Description |
-|------------|-------------|
-| **G** | Orientation géométrique root / normal / deviation |
-| **A** | Détection des clusters double switch |
-| **B** | Absorption du segment de liaison |
-| **C** | Validation CDC (`minBranchLength`) |
-| **D** | Détection des crossovers |
-| **E** | Cohérence des crossovers (branches partagées → DEVIATION) |
-| **F** | Calcul des tips CDC (`switchSideSize`) |
+2. **Passe 2 — SwitchBlocks :** Résout les pointeurs `root`, `normal`,
+   `deviation` depuis les IDs stockés dans les endpoints de branches.
 
-### G — Orientation géométrique
-
-Root, normal et deviation sont déterminés par heuristique vectorielle sur les
-positions UTM des blocs adjacents — sans dépendance GeoJSON ni donnée de sens de circulation :
-
-1. Calcule 3 vecteurs UTM unitaires depuis la jonction vers chaque branche.
-2. **Root** = branche dont le vecteur a le dot product minimal avec la résultante normalisée des deux autres (branche la plus opposée).
-3. **Normal** = des deux restantes, celle dont le dot product avec root est le plus négatif (continuation directe, angle ≈ 180°).
-4. **Deviation** = la troisième.
-
-```cpp
-// Résultante des branches j et k
-CoordinateXY resultant = normalize(vecs[j] + vecs[k]);
-double score = dot(vecs[i], resultant);  // minimum → root
-```
-
-### F — Tips CDC
-
-`interpolateTip()` parcourt la géométrie WGS84 du straight depuis l'extrémité
-la plus proche de la jonction et interpole le point à `config.switchSideSize` mètres
-(distance Haversine). Retourne l'extrémité distale si la branche est plus courte.
+> **Correctif v2 :** La vérification de `frontierNodeId != SIZE_MAX` avant
+> tout appel à `setNeighbour*` est essentielle pour ne pas écraser la chaîne
+> de subdivision posée par Phase 6.
 
 ---
 
-## Phase 8 — RepositoryTransfer {#gp_phase8}
+### Phase 7 — SwitchProcessor {#geo_p7}
 
-**Fichiers :** `Phase8_RepositoryTransfer.h/.cpp`
+**Classe :** @ref Phase7_SwitchProcessor
 
-Transfère `ctx.blocks` vers TopologyRepository. Scindée en deux appels
-dans l'orchestrateur pour respecter la contrainte d'ordre avec Phase 7.
+Traite les aiguillages en plusieurs sous-phases séquentielles (G→A→B→C→D→E→F) :
 
-**Ordre réel dans GeoParser::parse() "GeoParser::parse()" :**
+| Sous-phase | Rôle |
+|------------|------|
+| G — DoubleSwitchDetector | Détecte les paires d'aiguilles doubles et marque l'absorption |
+| A — OrientationResolver | Identifie root/normal/deviation par analyse angulaire |
+| B — CDCTipInterpolator | Interpole les tips CDC à distance `switchSideSize` |
+| C — StraightTrimmer | Recule les extrémités des straights adjacents |
+| D — OverlapResolver | Résout les chevauchements restants |
+| E — BranchValidator | Valide la cohérence des branches |
+| F — DoubleAbsorber | Absorbe les coordonnées du segment de liaison |
 
-```
-Phase8_RepositoryTransfer::resolve(ctx)   — résolution pointeurs
-Phase7_SwitchProcessor::run(ctx, ...)     — orientation (nécessite pointeurs)
-Phase8_RepositoryTransfer::transfer(ctx)  — std::move → TopologyRepository + buildIndex()
-```
+**Paramètres clés :** `config.junctionTrimMargin`, `config.switchSideSize`,
+`config.doubleSwitchRadius`
 
-| Méthode | Rôle |
-|---------|------|
-| Phase8_RepositoryTransfer::resolve() "resolve()" | Résolution des `ShuntingElement*` inter-blocs depuis les IDs câblés en Phase 6 |
-| Phase8_RepositoryTransfer::transfer() "transfer()" | `std::move` des `unique_ptr` → TopologyData + `buildIndex()` |
-
-### resolveStraight — préservation de la chaîne
-
-`resolveStraight()` ne modifie `setNeighbourPrev/Next` que si `neighbourId` est non vide.
-Les sous-blocs internes d'un straight subdivisé (`frontierNodeId == SIZE_MAX`, `neighbourId == ""`)
-ne sont jamais touchés — leur chaîne `prev/next` posée par Phase 6 est préservée.
-
-**Stabilité des adresses :** TopologyData stocke en `vector<unique_ptr<T>>`.
-Après `std::move`, les adresses des objets alloués sont stables — les pointeurs
-résolus par `resolve()` restent valides après le transfert.
+> **Issue connue (différé) :** `DoubleSwitchDetector` échoue sur certaines
+> configurations de crossover où la branche déviation du premier switch pointe
+> vers le straight de liaison plutôt que vers le second switch.
 
 ---
 
-# GeoParsingTask — Intégration async {#gp_task}
+### Phase 8b — RepositoryTransfer::transfer() {#geo_p8b}
 
-GeoParsingTask est le point d'entrée depuis `MainWindow`.
+**Classe :** @ref Phase8_RepositoryTransfer, méthode `transfer()`
 
-```cpp
-void GeoParsingTask::start(const std::string& filePath,
-                            const ParserConfig& config);
-void GeoParsingTask::cancel();
-```
+Transfère l'ownership des blocs depuis `ctx.blocks` vers
+@ref TopologyRepository par déplacement (`std::move`). Appelle ensuite
+`TopologyData::buildIndex()` pour construire les maps `id → ptr`.
 
-**Cancel token partagé :**
-
-```
-GeoParsingTask
-  └── m_cancelToken : shared_ptr<atomic<bool>>
-        └── copié dans le thread détaché → partagé avec GeoParser
-```
-
-Le thread vérifie `*m_cancelToken` entre les phases. Si `true`, il envoie
-`WM_PARSING_CANCELLED` et s'arrête proprement sans altérer TopologyRepository.
-
-| Message Win32 | Contenu | Handler |
-|---------------|---------|---------|
-| `WM_PROGRESS_UPDATE` | Avancement 0–100 | `MainWindow::onProgressUpdate()` |
-| `WM_PARSING_SUCCESS` | — | `MainWindow::onParsingSuccess()` |
-| `WM_PARSING_ERROR` | `std::string*` (à libérer) | `MainWindow::onParsingError()` |
-| `WM_PARSING_CANCELLED` | — | `MainWindow::onParsingCancelled()` |
+Après `transfer()`, le `PipelineContext` est vide et le `TopologyRepository`
+est le seul détenteur des blocs.
 
 ---
 
-# ParserSettingsDialog {#gp_dialog}
+## Exécution asynchrone — GeoParsingTask {#geo_task}
 
-**Fichiers :** `Engine/HMI/Dialogs/ParserSettingsDialog.h/.cpp`
+@ref GeoParsingTask encapsule l'exécution du pipeline dans un **thread
+séparé** pour ne pas bloquer le thread UI Win32. Elle :
 
-Dialogue modal Win32 permettant à l'utilisateur de modifier les 8 paramètres
-de `ParserConfig` depuis l'interface.
-
-**Comportement :**
-- 8 contrôles `EDIT` Win32 (dont `IDC_EDIT_SWITCH_SIDE_SIZE` pour `switchSideSize`)
-- Validation des plages (valeurs positives, cohérence `intersectionEpsilon` < `snapTolerance`)
-- Boutons **OK** / **Annuler** / **Réinitialiser aux défauts**
-- OK → `ParserConfigIni::save()` → rechargement dans `MainWindow`
-
-**Pattern :** `DialogBoxParam` / `WM_INITDIALOG` / `IDOK` / `IDCANCEL`.
+- Instancie un @ref GeoParser avec la @ref ParserConfig courante.
+- Lance `parse()` dans `std::async`.
+- Poste des messages `WM_PROGRESS_UPDATE`, `WM_PARSING_SUCCESS` ou
+  `WM_PARSING_ERROR` vers la `HWND` de la `MainWindow`.
+- Expose un `cancelToken` (`shared_ptr<atomic<bool>>`) vérifié entre chaque
+  phase — l'annulation propre lève `GeoParser::CancelledException`.
 
 ---
+
+## Progression rapportée {#geo_progress}
+
+| Phase | Progression |
+|-------|-------------|
+| Phase 1 | 0 % |
+| Phase 2 | 5 % |
+| Phase 3 | 30 % |
+| Phase 4 | 45 % |
+| Phase 5 | 58 % |
+| Phase 6 | 65 % |
+| Phase 8a + Phase 7 | 75 % |
+| Phase 8b | 90 % |
+| Terminé | 100 % |
+
+---
+
+## Références croisées {#geo_refs}
+
+| Classe | Fichier | Rôle |
+|--------|---------|------|
+| @ref GeoParser | `Modules/GeoParser/GeoParser.h` | Orchestrateur |
+| @ref GeoParsingTask | `Modules/GeoParser/GeoParsingTask.h` | Thread asynchrone |
+| @ref PipelineContext | `Modules/GeoParser/Pipeline/PipelineContext.h` | Données partagées |
+| @ref BlockSet | `Modules/GeoParser/Pipeline/BlockSet.h` | Blocs produits par Phase 6 |
+| @ref BlockEndpoint | `Modules/GeoParser/Pipeline/BlockSet.h` | Extrémité d'un bloc |
+| @ref Phase1_GeoLoader | `Modules/GeoParser/Pipeline/Phase1_GeoLoader.h` | Chargement GeoJSON |
+| @ref Phase2_GeometricIntersector | `Modules/GeoParser/Pipeline/Phase2_GeometricIntersector.h` | Intersections |
+| @ref Phase3_NetworkSplitter | `Modules/GeoParser/Pipeline/Phase3_NetworkSplitter.h` | Découpe et snap |
+| @ref Phase4_TopologyBuilder | `Modules/GeoParser/Pipeline/Phase4_TopologyBuilder.h` | Graphe topologique |
+| @ref Phase5_SwitchClassifier | `Modules/GeoParser/Pipeline/Phase5_SwitchClassifier.h` | Classification nœuds |
+| @ref Phase6_BlockExtractor | `Modules/GeoParser/Pipeline/Phase6_BlockExtractor.h` | Extraction des blocs |
+| @ref Phase7_SwitchProcessor | `Modules/GeoParser/Pipeline/Phase7_SwitchProcessor.h` | Traitement aiguillages |
+| @ref Phase8_RepositoryTransfer | `Modules/GeoParser/Pipeline/Phase8_RepositoryTransfer.h` | Résolution + transfert |
+| @ref ParserConfig | `Engine/Core/Config/ParserConfig.h` | Paramètres pipeline |

--- a/docs/doxygen/pages/hmi.md
+++ b/docs/doxygen/pages/hmi.md
@@ -1,0 +1,197 @@
+@page page_hmi Interface graphique (HMI)
+
+@tableofcontents
+
+---
+
+## Vue d'ensemble {#hmi_overview}
+
+Le module **HMI** (Human-Machine Interface) regroupe l'ensemble des composants
+de l'interface graphique Win32. Il orchestre l'affichage, les interactions
+utilisateur et la communication entre les modules métier.
+
+| Composant | Classe | Rôle |
+|-----------|--------|------|
+| Fenêtre principale | @ref MainWindow | Dispatcher WM_*, menu, dialogs |
+| Carte interactive | @ref WebViewPanel + @ref Leaflet | Carte ferroviaire Leaflet.js |
+| Panneau PCC | @ref PCCPanel | TCO schématique GDI |
+| Barre de progression | @ref ProgressBar | Avancement du parsing |
+| Dialogs | `AboutDialog`, `ParserSettingsDialog`, … | Boîtes de dialogue modales |
+
+---
+
+## MainWindow {#hmi_mainwindow}
+
+@ref MainWindow est la fenêtre principale Win32. Elle est instanciée dans
+`WinMain` et ne doit exister qu'en une seule instance.
+
+### Cycle de vie
+
+```
+WinMain
+  └── MainWindow::create()
+        ├── CreateWindowW()         → m_hWnd
+        ├── ShowWindow/UpdateWindow
+        ├── ProgressBar::create()
+        ├── ParserConfigIni::load() → m_parserConfig
+        ├── GeoParsingTask (instanciation différée)
+        ├── WebViewPanel::create()  → WebView2 COM async
+        └── PCCPanel::create()
+```
+
+`create()` est synchrone pour tout sauf l'initialisation de WebView2, qui
+s'effectue de manière asynchrone via des callbacks COM (voir
+@ref hmi_webview).
+
+### Dispatcher de messages
+
+Le `WndProc` statique récupère le pointeur `this` depuis `GWLP_USERDATA`
+(positionné dans `WM_NCCREATE`) et délègue chaque message à une méthode
+membre :
+
+| Message Win32 | Méthode | Déclencheur |
+|---------------|---------|-------------|
+| `WM_COMMAND` | `onCommand()` | Menu, boutons |
+| `WM_SIZE` | `onSizeUpdate()` | Redimensionnement |
+| `WM_DESTROY` | `onDestroy()` | Fermeture |
+| `WM_PROGRESS_UPDATE` | `onProgressUpdate()` | Thread parsing (PostMessage) |
+| `WM_PARSING_SUCCESS` | `onParsingSuccess()` | Thread parsing (PostMessage) |
+| `WM_PARSING_ERROR` | `onParsingError()` | Thread parsing (PostMessage) |
+| `WM_PARSING_CANCELLED` | `onParsingCancelled()` | Thread parsing (PostMessage) |
+
+### Communication inter-threads
+
+Le pipeline GeoParser s'exécute dans un **thread séparé**
+(@ref GeoParsingTask). La communication vers le thread UI passe exclusivement
+par `PostMessage()` avec des messages personnalisés définis dans `Resource.h` :
+
+| Message | wParam | lParam |
+|---------|--------|--------|
+| `WM_PROGRESS_UPDATE` | progression 0-100 | `wstring*` label (alloué par tâche, libéré par `onProgressUpdate`) |
+| `WM_PARSING_SUCCESS` | 0 | 0 |
+| `WM_PARSING_ERROR` | 0 | `wstring*` message (alloué par tâche, libéré par `onParsingError`) |
+| `WM_PARSING_CANCELLED` | 0 | 0 |
+
+> **Règle mémoire :** tout `wstring*` transmis en `lParam` est alloué par
+> la tâche avec `new` et **libéré par le handler** après extraction. Ne
+> jamais accéder à un `lParam` après le `delete`.
+
+### Interaction aiguillage (Leaflet → C++)
+
+Un clic sur un marqueur aiguillage dans la carte Leaflet déclenche :
+
+```
+JS: window.chrome.webview.postMessage(JSON.stringify({type:"switch", id:"sw/3"}))
+   ↓
+WebViewPanel::onWebMessageReceived()
+   ↓
+m_onMessageReceived callback → MainWindow::onWebMessage()
+   ↓
+MainWindow::onSwitchClick("sw/3")
+   ↓
+SwitchBlock::toggleActiveBranch(true)
+   ↓
+TopologyRenderer::updateSwitchBlocks(*sw) → executeScript()
+```
+
+---
+
+## WebViewPanel et Leaflet {#hmi_webview}
+
+### WebViewPanel
+
+@ref WebViewPanel encapsule le contrôle **WebView2** (navigateur Chromium
+embarqué via COM). Il fournit une API C++ de haut niveau indépendante des
+interfaces `ICoreWebView2*` :
+
+| Méthode | Rôle |
+|---------|------|
+| `create(parentHwnd)` | Lance l'initialisation asynchrone WebView2 |
+| `navigate(url)` | Navigation vers une URL |
+| `navigateToString(html)` | Injection directe de HTML |
+| `executeScript(js)` | Exécute du JavaScript dans la page courante |
+| `setOnMessageReceived(cb)` | Enregistre le handler des messages `postMessage` JS |
+| `setVirtualHostMapping(host, dir)` | Mappe un hôte virtuel vers un dossier local |
+| `resize()` | Adapte WebView à la taille de la fenêtre parente |
+| `close()` | Libère les ressources COM |
+
+**Initialisation asynchrone :** `create()` appelle
+`CreateCoreWebView2EnvironmentWithOptions()`. Le résultat arrive dans
+`onEnvironmentCreated()` (callback WRL), qui enchaîne
+`CreateCoreWebView2Controller()`, puis `onControllerCreated()` finalise
+l'initialisation et appelle `m_onInitialized` si enregistré.
+
+**Conversion de messages :** les messages JavaScript sont reçus en UTF-16.
+Le handler `onWebMessageReceived()` les convertit en UTF-8 (`std::string`)
+avant de les transmettre au callback `m_onMessageReceived`.
+
+### Leaflet
+
+@ref Leaflet est un utilitaire statique qui génère la **page HTML complète**
+intégrant la bibliothèque Leaflet.js (chargée depuis un CDN). La page expose
+une API JavaScript appelable depuis C++ via `executeScript()` :
+
+| Fonction JS | Appelée depuis | Rôle |
+|-------------|----------------|------|
+| `renderStraightBlock(id, coords)` | `TopologyRenderer` | Trace une section de voie |
+| `renderSwitch(id, lat, lon)` | `TopologyRenderer` | Place un marqueur aiguillage |
+| `renderSwitchBranches(id, ...)` | `TopologyRenderer` | Trace les stubs CDC |
+| `switchApplyState(id, state)` | `TopologyRenderer` | Met à jour la couleur d'un switch |
+| `clearStraightBlocks()` | `TopologyRenderer` | Supprime toutes les voies |
+| `clearSwitches()` | `TopologyRenderer` | Supprime tous les aiguillages |
+| `zoomToStraights()` | `TopologyRenderer` | Ajuste la vue à l'emprise |
+| `loadGeoJson(json)` | `TopologyRenderer` | Charge un GeoJSON complet |
+
+La page est initialement vide (fond OpenStreetMap, centre Paris). Le premier
+rendu est déclenché dans `MainWindow::onParsingSuccess()` via
+`TopologyRenderer::renderAllTopology()`.
+
+---
+
+## Panneau PCC {#hmi_pcc}
+
+Voir @ref page_pcc pour la documentation détaillée du module PCC/TCO.
+
+@ref PCCPanel est une fenêtre Win32 enfant (style `WS_CHILD | WS_VISIBLE`)
+positionnée par `MainWindow::onSizeUpdate()` pour couvrir la zone d'affichage.
+Elle est togglée visible/invisible via `F2` ou le menu `Vue → PCC`.
+
+---
+
+## Dialogs {#hmi_dialogs}
+
+| Classe | Raccourci | Description |
+|--------|-----------|-------------|
+| `AboutDialog` | Menu Aide | Boîte À propos |
+| `FileOpenDialog` | `Ctrl+O` | Sélecteur GeoJSON (IFileOpenDialog COM) |
+| `FileSaveDialog` | `Ctrl+E` | Sélecteur de destination pour l'export GeoJSON |
+| `ParserSettingsDialog` | `Ctrl+P` | Formulaire de paramètres `ParserConfig` avec bouton Réinitialiser |
+
+`ParserSettingsDialog` expose des contrôles `EDIT` pour chaque paramètre
+numérique de @ref ParserConfig. À la validation, la config est sauvegardée
+via `ParserConfigIni::save()` dans `m_parserIniPath`.
+
+---
+
+## Barre de progression {#hmi_progressbar}
+
+@ref ProgressBar encapsule un contrôle natif `PROGRESS_CLASS` Win32 avec
+un bouton **Annuler** (`IDC_CANCEL_PARSING`). Elle affiche un label de phase
+en superposition.
+
+`show(true)` / `show(false)` gèrent la visibilité de l'ensemble
+(barre + bouton + label) pour ne pas encombrer l'interface hors parsing.
+
+---
+
+## Références croisées {#hmi_refs}
+
+| Classe | Fichier | Rôle |
+|--------|---------|------|
+| @ref MainWindow | `Engine/HMI/MainWindow.h` | Fenêtre principale |
+| @ref WebViewPanel | `Engine/HMI/WebViewPanel/WebViewPanel.h` | Contrôle WebView2 |
+| @ref Leaflet | `Engine/HMI/WebViewPanel/Leaflet/Leaflet.h` | Générateur HTML Leaflet |
+| @ref PCCPanel | `Engine/HMI/PCCPanel/PCCPanel.h` | Panneau TCO Win32 |
+| @ref ProgressBar | `Engine/HMI/Utils/ProgressBar.h` | Barre de progression |
+| @ref GeoParsingTask | `Modules/GeoParser/GeoParsingTask.h` | Thread parsing |
+| @ref TopologyRenderer | `Engine/Core/Topology/TopologyRenderer.h` | Scripts Leaflet |

--- a/docs/doxygen/pages/interactiveElements.md
+++ b/docs/doxygen/pages/interactiveElements.md
@@ -1,0 +1,203 @@
+@page page_elements Éléments interactifs ferroviaires
+
+@tableofcontents
+
+---
+
+## Vue d'ensemble {#elem_overview}
+
+Le module **Elements** constitue le **modèle de domaine** du simulateur.
+Il fournit la hiérarchie de classes représentant les objets physiques de
+l'infrastructure ferroviaire — sections de voie et aiguillages — dans leur
+état opérationnel courant.
+
+Ces classes sont produites par le @ref page_geoparser "pipeline GeoParser",
+stockées dans @ref TopologyData et consommées par le
+@ref page_pcc "module PCC" et le rendu WebView.
+
+---
+
+## Hiérarchie de classes {#elem_hierarchy}
+
+```
+Element                     (classe abstraite — id, type)
+└── ShuntingElement         (ajoute getState() / ShuntingState)
+    ├── StraightBlock       (section de voie droite)
+    └── SwitchBlock         (aiguillage 3 branches)
+```
+
+La hiérarchie est délibérément plate : deux niveaux d'abstraction suffisent
+pour couvrir l'ensemble de l'infrastructure cible.
+
+---
+
+## Element {#elem_element}
+
+@ref Element est la racine abstraite. Elle impose deux contrats minimaux :
+
+- **`getId()`** — identifiant unique sous la forme `"s/N"` (straight) ou
+  `"sw/N"` (switch), attribué par le pipeline lors de la Phase 6.
+- **`getType()`** — discriminant `ElementType::STRAIGHT` ou
+  `ElementType::SWITCH`, utilisé pour éviter le `dynamic_cast` dans le
+  code de rendu critique.
+
+La copie est interdite (risque de *slicing*). Le déplacement est autorisé
+pour les constructions par `make_unique` et les insertions en vecteur.
+
+### Logger partagé
+
+Tous les éléments partagent un unique `Logger m_logger("Elements")` déclaré
+**statique** dans `Element`. Cela garantit qu'un seul fichier
+`Logs/Elements.log` est créé, même en présence de centaines d'instances.
+Le mutex interne au `Logger` assure la thread-safety.
+
+---
+
+## ShuntingElement {#elem_shunting}
+
+@ref ShuntingElement étend `Element` avec la notion d'**état opérationnel** :
+
+| @ref ShuntingState | Signification |
+|--------------------|---------------|
+| `FREE` | Élément libre, opérationnel (défaut) |
+| `OCCUPIED` | Un véhicule est présent sur l'élément |
+| `INACTIVE` | Hors service — panne ou maintenance |
+
+Les accesseurs de commodité `isFree()`, `isOccupied()`, `isInactive()` évitent
+les comparaisons répétitives avec l'enum.
+
+L'état est mutable en runtime par l'opérateur (clic Leaflet sur un aiguillage)
+ou par la simulation. Les mutations passent par `setState()`.
+
+> **Note de conception :** Le destructeur virtuel de `ShuntingElement`
+> supprimerait la génération implicite des opérateurs de déplacement en C++17.
+> Ils sont donc réexplicitement déclarés `= default` pour maintenir la
+> déplaçabilité requise par `std::unique_ptr` et `std::vector`.
+
+---
+
+## StraightBlock {#elem_straight}
+
+@ref StraightBlock représente une **section de voie droite** (tronçon entre
+deux nœuds frontières, ou entre deux sous-blocs de subdivision).
+
+### Géométrie
+
+Chaque straight porte deux polylignes parallèles :
+
+| Collection | Système | Usage |
+|------------|---------|-------|
+| `pointsWGS84` | WGS-84 (lat/lon) | Rendu Leaflet via `TopologyRenderer` |
+| `pointsUTM` | UTM zone 30N (x=est, y=nord, mètres) | Calculs métriques pipeline |
+
+Les deux collections ont **toujours la même taille** et les mêmes indices :
+`pointsWGS84[i]` et `pointsUTM[i]` désignent le même point physique.
+
+`getLengthMeters()` retourne la longueur Haversine calculée sur WGS-84.
+`getLengthUTM()` retourne la longueur euclidienne calculée sur UTM.
+
+### Chaîne prev/next
+
+Quand `maxSegmentLength` est dépassé, le pipeline subdivise un straight en
+*N* sous-blocs. Les sous-blocs sont chaînés par des pointeurs non-propriétaires :
+
+```
+  s/0_c0 ──next──► s/0_c1 ──next──► s/0_c2
+         ◄──prev──          ◄──prev──
+```
+
+Ces pointeurs sont posés par @ref Phase6_BlockExtractor::registerStraight
+**avant** la résolution de Phase 8. Seuls les sous-blocs de tête et de queue
+ont des endpoints avec un `frontierNodeId` valide.
+
+### Voisins topologiques
+
+`getNeighbourNext()` / `getNeighbourPrev()` retournent les blocs adjacents
+(straight ou switch) après résolution par @ref Phase8_RepositoryTransfer.
+`getPCCNeighbours()` expose les deux sans distinguer next/prev — utilisé par
+@ref PCCGraphBuilder pour construire les arêtes STRAIGHT.
+
+---
+
+## SwitchBlock {#elem_switch}
+
+@ref SwitchBlock représente un **aiguillage ferroviaire à 3 branches**.
+
+### Anatomie d'un aiguillage
+
+```
+              ← root
+             /
+jonction ───┤
+             \
+              ← normal     (voie directe, position repos)
+               \
+                ← deviation (voie déviée, position basculée)
+```
+
+Le point de **jonction** (`junctionWGS84` / `junctionUTM`) est la position
+physique de l'aiguillage sur la carte.
+
+Chaque branche est identifiée par l'ID du bloc adjacent (`rootId`,
+`normalId`, `deviationId`) et par un pointeur résolu (`root`, `normal`,
+`deviation`) vers le @ref ShuntingElement correspondant.
+
+### État actif
+
+@ref ActiveBranch indique la voie ouverte :
+
+| Valeur | Signification | Couleur TCO |
+|--------|---------------|-------------|
+| `NORMAL` | Voie directe — position repos | Trait horizontal plein |
+| `DEVIATION` | Voie déviée — position basculée | Branche oblique active |
+
+`toggleActiveBranch(propagate)` inverse l'état et propage aux partenaires
+double-aiguille si `propagate == true`.
+
+### Tips CDC
+
+Les **tips CDC** (*Centre De Contre*) sont les extrémités des stubs de
+l'aiguillage sur le schéma TCO. Ils sont interpolés par
+@ref Phase7_SwitchProcessor à distance `switchSideSize` de la jonction,
+en direction de chaque branche :
+
+| Accesseur | Branche |
+|-----------|---------|
+| `getTipOnRoot()` / `getTipOnRootUTM()` | Branche root |
+| `getTipOnNormal()` / `getTipOnNormalUTM()` | Branche normale |
+| `getTipOnDeviation()` / `getTipOnDeviationUTM()` | Branche déviée |
+
+### Double aiguille
+
+Un switch peut **absorber** le segment de liaison de son partenaire :
+
+```
+sw/A ──────────────────── sw/B
+     ↑ segment absorbé ↑
+```
+
+L'absorption est stockée dans `doubleOnNormal` ou `doubleOnDeviation`
+(ID du partenaire) et dans `absorbedNormalCoords` / `absorbedDeviationCoords`
+(polyligne WGS-84 absorbée pour le rendu Leaflet).
+
+`isDouble()` retourne `true` si l'une des deux absorptions est renseignée.
+
+### Orientation
+
+Un switch est **orienté** après exécution de @ref Phase7_SwitchProcessor.
+`isOriented()` conditionne le rendu des branches dans `TCORenderer` et
+`TopologyRenderer`.
+
+---
+
+## Références croisées {#elem_refs}
+
+| Classe / enum | Fichier | Rôle |
+|---------------|---------|------|
+| @ref Element | `Modules/Elements/Element.h` | Base abstraite |
+| @ref ElementType | `Modules/Elements/Element.h` | Discriminant SWITCH/STRAIGHT |
+| @ref ShuntingElement | `Modules/Elements/ShuntingElements/ShuntingElement.h` | Ajoute getState() |
+| @ref ShuntingState | `Modules/Elements/ShuntingElements/ShuntingElement.h` | FREE/OCCUPIED/INACTIVE |
+| @ref StraightBlock | `Modules/Elements/ShuntingElements/StraightBlock.h` | Section de voie |
+| @ref SwitchBlock | `Modules/Elements/ShuntingElements/SwitchBlock.h` | Aiguillage 3 branches |
+| @ref ActiveBranch | `Modules/Elements/ShuntingElements/SwitchBlock.h` | NORMAL/DEVIATION |

--- a/docs/doxygen/pages/mainpage.md
+++ b/docs/doxygen/pages/mainpage.md
@@ -1,58 +1,118 @@
-@mainpage Simulateur Ferroviaire
+@mainpage SimulateurFerroviaire — Documentation technique
 
 @tableofcontents
 
 ---
 
-# Description {#description}
+## Présentation {#mainpage_intro}
 
-Reconstruction et visualisation d'un réseau ferroviaire à partir de données GeoJSON.
+**SimulateurFerroviaire** est un simulateur ferroviaire Win32/C++ ciblant la ligne
+**Saujon – La Tremblade** (Charente-Maritime). Il reconstitue la topologie réelle
+du réseau à partir de données géographiques ouvertes (GeoJSON OpenStreetMap) et en
+produit une représentation schématique interactive conforme aux standards SNCF de
+contrôle du mouvement (PCC/TCO).
 
-Le projet repose sur un pipeline de parsing permettant de :
-- Charger des données géographiques (WGS-84 / GeoJSON)
-- Construire un graphe topologique métrique (UTM)
-- Extraire les blocs ferroviaires (voies droites + aiguillages)
-- Orienter et valider les aiguillages (root / normal / deviation)
-- Détecter les doubles aiguilles et absorber les segments de liaison
-- Résoudre les pointeurs inter-blocs et construire les index de lookup
-- Stocker le modèle dans un singleton partagé et le visualiser dans un WebView
-- Permettre une interaction bidirectionnelle Leaflet ↔ C++ (clic → mise à jour modèle → rendu)
-- Afficher une vue PCC type TCO SNCF superposée à la carte, togglable via F2
+L'application est développée sous **Visual Studio 2022**, compilée en **x64** sur
+**Windows 11**, avec les bibliothèques système Win32, WebView2 (COM) et GDI.
 
 ---
 
-# Architecture du projet {#diag}
+## Modules {#mainpage_modules}
 
-![Architecture SimulateurFerroviaire](architecture.svg)
+Le projet est découpé en quatre grandes zones fonctionnelles, reflétées dans
+l'arborescence des sources :
 
----
-
-# Documentation
-
-- @subpage engine                  — Moteur de l'application
-- @subpage geoparser               — Module de parsing GeoJson
-- @subpage elements                — Module Éléments — Modèle de domaine ferroviaire
-- @subpage pcc                     — Module PCC
-- @subpage references              — Références externes
-
----
-
-# Licence {#licence}
-
-Ce projet est distribué sous licence :
-
-**Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)**
-
-https://creativecommons.org/licenses/by-nc-sa/4.0/
-
-- Partager — copier et redistribuer le matériel
-- Adapter — remixer, transformer et créer à partir du matériel
-- Attribution requise
-- Usage commercial interdit
-- Redistribution sous la même licence
+| Module | Espace de noms / dossier | Rôle |
+|--------|--------------------------|------|
+| @ref page_elements "Éléments interactifs" | `Modules/Elements/` | Modèle de domaine — blocs de voie et aiguillages |
+| @ref page_geoparser "GeoParser v2" | `Modules/GeoParser/` | Pipeline de conversion GeoJSON → topologie |
+| @ref page_pcc "PCC / TCO" | `Modules/PCC/` | Graphe logique et rendu du tableau de contrôle |
+| @ref page_engine "Engine Core" | `Engine/Core/` | Logger, coordonnées, topologie, configuration |
+| @ref page_hmi "HMI" | `Engine/HMI/` | Fenêtre principale, WebView2, panneau PCC |
 
 ---
 
-# Auteur {#auteur}
+## Flux de données {#mainpage_flux}
 
-© 2026 Valentin Eloy
+```
+Fichier GeoJSON
+      │
+      ▼
+┌─────────────────┐
+│  GeoParser v2   │   8 phases de transformation
+│  (pipeline)     │──────────────────────────────────► TopologyRepository
+└─────────────────┘                                         (singleton)
+                                                               │
+                    ┌──────────────────────────────────────────┤
+                    │                                          │
+                    ▼                                          ▼
+            ┌──────────────┐                       ┌─────────────────┐
+            │  PCCPanel    │◄──── PCCGraphBuilder   │  WebViewPanel   │
+            │  (Win32/GDI) │       + PCCLayout      │  (Leaflet.js)   │
+            │  TCORenderer │                        │  TopologyRender │
+            └──────────────┘                        └─────────────────┘
+```
+
+L'unique point de partage entre les modules est le singleton
+@ref TopologyRepository, qui expose un @ref TopologyData immuable après
+le parsing.
+
+---
+
+## Démarrage rapide {#mainpage_quickstart}
+
+### Charger un GeoJSON
+
+1. Lancer l'application.
+2. Fichier → Ouvrir (`Ctrl+O`) → sélectionner un fichier `.geojson`.
+3. La barre de progression affiche l'avancement des 8 phases du pipeline.
+4. En cas de succès, la carte Leaflet affiche la topologie et le panneau
+   PCC est disponible via `F2`.
+
+### Ajuster les paramètres du pipeline
+
+Menu **Fichier → Paramètres du parser** (`Ctrl+P`) ouvre
+@ref ParserSettingsDialog. Les valeurs sont persistées dans
+`parser_config.ini` (voir @ref ParserConfigIni).
+
+Paramètres clés :
+
+| Paramètre | Défaut | Description |
+|-----------|--------|-------------|
+| `snapTolerance` | 1,0 m | Distance maximale entre deux extrémités pour les fusionner |
+| `maxSegmentLength` | 200,0 m | Longueur au-delà de laquelle un straight est subdivisé |
+| `minSwitchAngle` | 5,0 ° | Angle minimum pour qu'une bifurcation soit classée SWITCH |
+| `junctionTrimMargin` | 3,0 m | Recul des tips CDC depuis la jonction |
+| `switchSideSize` | 15,0 m | Demi-longueur des stubs pour l'interpolation des tips |
+| `doubleSwitchRadius` | 20,0 m | Rayon de détection des aiguilles doubles |
+
+### Interagir avec la topologie
+
+- **Clic sur un aiguillage** dans la carte Leaflet → bascule
+  `NORMAL` ↔ `DEVIATION` et propage aux partenaires double-aiguille.
+- **Panneau PCC** (`F2`) → TCO schématique zoomable/pannable
+  (molette + glisser).
+
+---
+
+## Conventions de code {#mainpage_conventions}
+
+| Élément | Convention |
+|---------|------------|
+| Noms de variables et fonctions | **Anglais** |
+| Docstrings Doxygen | **Français** |
+| Système de coordonnées métrique | **UTM zone 30N** |
+| Système de coordonnées géographique | **WGS-84** |
+| Gestion d'erreur fatale | `LOG_FAILURE` → `std::runtime_error` |
+| Ownership des blocs | `std::unique_ptr` dans `TopologyData` |
+| Pointeurs non-propriétaires | Pointeurs bruts annotés `non-propriétaire` |
+
+---
+
+## Voir aussi {#mainpage_seealso}
+
+- @ref page_geoparser — pipeline de transformation GeoJSON
+- @ref page_pcc — graphe PCC et rendu TCO
+- @ref page_elements — hiérarchie des blocs ferroviaires
+- @ref page_engine — services transversaux (Logger, coordonnées, config)
+- @ref page_hmi — interface graphique Win32 / WebView2

--- a/docs/doxygen/pages/pcc.md
+++ b/docs/doxygen/pages/pcc.md
@@ -1,126 +1,261 @@
-@page pcc Module PCC — Graphe logique et rendu TCO
+@page page_pcc Module PCC / TCO
 
 @tableofcontents
 
 ---
 
-# Vue d'ensemble {#pcc_overview}
+## Vue d'ensemble {#pcc_overview}
 
-Le module PCC transforme le modèle topologique (@ref StraightBlock / @ref SwitchBlock)
-en un **graphe logique indépendant des coordonnées GPS**, positionnable en schéma
-gauche → droite pour l'affichage TCO.
+Le module **PCC** (Poste de Commandement Centralisé) produit et affiche un
+**Tableau de Contrôle Optique (TCO)** schématique du réseau ferroviaire.
 
-```
-TopologyRepository      Modules/PCC       HMI/PCCPanel
-  StraightBlock  ────┬─►  PCCNode  ────►  TCORenderer
-  SwitchBlock    ────┘       │
-                          PCCEdge
-                             │
-                          PCCGraph
-```
+Il opère en deux temps :
 
-**Règle de dépendance :**
-- `Modules/PCC` lit @ref TopologyRepository — seul point de couplage vers le GeoParser.
-- `HMI/PCCPanel` consomme @ref PCCGraph uniquement — jamais @ref TopologyRepository directement.
+1. **Construction du graphe** (@ref PCCGraphBuilder) : transformation du
+   @ref TopologyData en un graphe logique orienté de nœuds et d'arêtes PCC.
+2. **Positionnement BFS** (@ref PCCLayout) : attribution d'une position
+   logique `(x, y)` à chaque nœud par parcours en largeur.
+3. **Rendu GDI** (@ref TCORenderer) : projection des positions logiques vers
+   des coordonnées écran et tracé dans un `HDC` Win32.
 
-| Classe | Responsabilité unique |
-|--------|----------------------|
-| @ref PCCNode | Représenter un bloc ferroviaire dans le graphe |
-| @ref PCCStraightNode | Exposer les données spécifiques d'une voie droite |
-| @ref PCCSwitchNode | Exposer les données spécifiques d'un aiguillage |
-| @ref PCCEdge | Représenter une connexion orientée entre deux nœuds |
-| @ref PCCGraph | Posséder et indexer les nœuds et arêtes |
-| @ref PCCGraphBuilder | Construire le graphe depuis @ref TopologyRepository |
-| @ref PCCLayout | Calculer les positions logiques X/Y |
+> **Principe fondamental :** le layout PCC est **purement topologique**.
+> Les coordonnées GPS ne sont autorisées qu'une seule fois — dans
+> `PCCGraphBuilder::computeDeviationSides()` — pour déterminer le côté
+> géographique (±1) de la branche déviée de chaque aiguillage.
+> Toute autre valeur de position découle de la topologie de voisinage.
 
 ---
 
-# Nœuds et arêtes {#pcc_nodes}
+## Modèle de graphe {#pcc_model}
 
-```
-PCCEdge          — connexion orientée (from → to) + rôle sémantique
-PCCNode          — nœud abstrait (bloc ferroviaire + position logique)
-PCCStraightNode  — nœud voie droite → getStraightSource() : StraightBlock*
-PCCSwitchNode    — nœud aiguillage  → getSwitchSource()   : SwitchBlock*
-                                      getRootEdge() / getNormalEdge() / getDeviationEdge()
-```
+### Nœuds — PCCNode
 
-**Hiérarchie :**
-```
-PCCNode  (abstrait)
-  ├── PCCStraightNode
-  └── PCCSwitchNode
-```
+@ref PCCNode est la classe abstraite de base. Deux sous-classes concrètes :
 
-**Rôles d'arête (`PCCEdgeRole`) :**
+| Sous-classe | Source | `getNodeType()` |
+|-------------|--------|-----------------|
+| @ref PCCStraightNode | `StraightBlock` | `PCCNodeType::STRAIGHT` |
+| @ref PCCSwitchNode | `SwitchBlock` | `PCCNodeType::SWITCH` |
 
-| Valeur | Description |
-|--------|-------------|
-| `STRAIGHT` | Connexion entre deux blocs adjacents sans switch |
-| `ROOT` | Connexion sur la branche root d'un @ref SwitchBlock |
-| `NORMAL` | Connexion sur la branche normale d'un @ref SwitchBlock |
-| `DEVIATION` | Connexion sur la branche déviée d'un @ref SwitchBlock |
+Chaque nœud porte :
+- `m_sourceId` — identifiant du bloc source (`"s/0"`, `"sw/3"`, …)
+- `m_source` — pointeur non-propriétaire vers le `ShuntingElement` (durée
+  de vie garantie par `TopologyRepository`)
+- `m_position` — coordonnées logiques `{x, y}` calculées par `PCCLayout`
+- `m_edges` — liste de pointeurs non-propriétaires vers les arêtes adjacentes
 
----
+### PCCSwitchNode — détails
 
-# PCCGraph — Conteneur {#pcc_graph}
+@ref PCCSwitchNode ajoute :
+- Pointeurs d'arêtes typées : `m_rootEdge`, `m_normalEdge`, `m_deviationEdge`
+  — accès O(1) sans parcourir `m_edges`.
+- `m_deviationSide` — côté géographique de la déviation (+1 nord / -1 sud),
+  calculé par `PCCGraphBuilder::computeDeviationSides()` via produit vectoriel
+  2D sur coordonnées UTM.
 
-@ref PCCGraph possède l'ensemble des nœuds et arêtes via `unique_ptr` et expose
-un index de lookup O(1) par `sourceId`.
+### Arêtes — PCCEdge
 
-```
-PCCGraph
-  ├── m_nodes  : vector<unique_ptr<PCCNode>>      propriétaire
-  ├── m_edges  : vector<unique_ptr<PCCEdge>>      propriétaire
-  └── m_index  : unordered_map<string, PCCNode*>  lookup O(1)
-```
+@ref PCCEdge est une arête **orientée** (`from` → `to`) portant un rôle
+sémantique :
 
-| Méthode | Rôle |
-|---------|------|
-| @ref PCCGraph::addStraightNode() "addStraightNode()" | Crée, stocke et indexe un @ref PCCStraightNode |
-| @ref PCCGraph::addSwitchNode() "addSwitchNode()" | Crée, stocke et indexe un @ref PCCSwitchNode |
-| @ref PCCGraph::addEdge() "addEdge()" | Crée, stocke et câble une @ref PCCEdge sur les deux nœuds |
-| @ref PCCGraph::findNode() "findNode()" | Lookup O(1) — retourne `nullptr` si absent |
-| @ref PCCGraph::clear() "clear()" | Vide nœuds, arêtes et index |
+| @ref PCCEdgeRole | Signification |
+|------------------|---------------|
+| `ROOT` | Connexion switch → branche root |
+| `NORMAL` | Connexion switch → branche normale |
+| `DEVIATION` | Connexion switch → branche déviée |
+| `STRAIGHT` | Connexion straight → straight adjacent |
 
----
+Les arêtes sont détenues par `PCCGraph` via `unique_ptr`. Les nœuds en
+reçoivent des pointeurs non-propriétaires via `PCCNode::addEdge()`.
 
-# PCCGraphBuilder — Construction {#pcc_builder}
+### PCCGraph
 
-Classe statique. Seule classe du module qui connaît @ref TopologyRepository.
-
-**Pipeline interne de @ref PCCGraphBuilder::build() "PCCGraphBuilder::build()" :**
-
-```
-Passe 1 — buildNodes()  : crée un nœud PCC par bloc (index complet)
-Passe 2 — buildEdges()  : résout les connexions via les IDs de voisins/branches
-```
-
-Les deux passes sont séparées — toutes les arêtes référencent des nœuds par ID,
-l'index doit être complet avant la résolution.
+@ref PCCGraph détient l'ensemble des nœuds (`unique_ptr<PCCNode>`) et des
+arêtes (`unique_ptr<PCCEdge>`). Il expose un index `id → PCCNode*` pour les
+lookups O(1) lors de la construction des arêtes.
 
 ---
 
-# PCCLayout — Positionnement {#pcc_layout}
+## Construction du graphe — PCCGraphBuilder {#pcc_builder}
 
-Classe statique. Calcule les positions logiques X/Y par parcours BFS.
+@ref PCCGraphBuilder construit le graphe en **trois passes** :
+
+### Passe 1 — buildNodes()
+
+Un nœud PCC est créé pour chaque `StraightBlock` et `SwitchBlock` présent
+dans `TopologyData`. Tous les nœuds sont indexés dans `PCCGraph` avant la
+passe 2.
+
+### Passe 2 — buildEdges()
+
+**Arêtes de switch :** pour chaque switch orienté, trois arêtes
+ROOT / NORMAL / DEVIATION sont créées depuis le nœud switch vers les nœuds
+des blocs branche. Les arêtes sont enregistrées dans `PCCSwitchNode` via
+`setRootEdge()` / `setNormalEdge()` / `setDeviationEdge()`.
+
+**Arêtes STRAIGHT :** pour chaque straight, `getNeighbours()` (pointeurs
+résolus par Phase 8) fournit les blocs adjacents. Une arête STRAIGHT est
+créée pour chaque connexion, avec dédoublonnage par clé canonique
+`makeEdgeKey(idA, idB)`.
+
+> **Correctif v2 :** `buildEdges()` utilise `StraightBlock::getNeighbours()`
+> (pointeurs résolus) et **non** `getNeighbourIds()` (IDs vides pour les
+> sous-blocs de subdivision produits par `Phase6`).
+
+### Passe 3 — computeDeviationSides()
+
+Pour chaque `PCCSwitchNode` avec un switch orienté et des tips CDC UTM
+disponibles, calcule le **produit vectoriel 2D** entre le vecteur
+jonction → tip root et le vecteur jonction → tip déviation :
 
 ```
-Avant PCCLayout          Après PCCLayout
-
-s/0  sw/0  s/1           s/0(x=0,y=0) ─ sw/0(x=1,y=0) ─┬─ s/1(x=2,y=0)
-                                                       └─ s/2(x=2,y=1)  ← déviation
+cross = rootX * devY - rootY * devX
+side = (cross > 0) ? +1 : -1
 ```
 
-**Règles de positionnement :**
+`side > 0` → déviation à gauche de root (vers le haut dans le TCO).
+`side < 0` → déviation à droite de root (vers le bas dans le TCO).
 
-| Arête empruntée | Effet sur Y |
-|-----------------|-------------|
-| ROOT / NORMAL / STRAIGHT | Y inchangé |
-| DEVIATION | Y + 1 (bifurcation vers le haut) |
+---
 
-| Méthode | Rôle |
-|---------|------|
-| @ref PCCLayout::compute() "compute()" | Point d'entrée — orchestre BFS multi-sources |
-| @ref PCCLayout::findTermini() "findTermini()" | Détecte les nœuds de départ (1 seul voisin, non-cible de switch) |
-| @ref PCCLayout::runBFS() "runBFS()" | BFS depuis un terminus, assigne PCCPosition |
+## Positionnement BFS — PCCLayout {#pcc_layout}
+
+### Principe
+
+@ref PCCLayout attribue une position logique `{x, y}` à chaque nœud par
+**parcours en largeur** depuis les nœuds terminus (degré 1 dans le graphe PCC).
+
+L'axe **X** représente la profondeur de progression le long du réseau.
+L'axe **Y** représente le décalage vertical des branches déviées.
+
+### Recherche des terminus
+
+`findTermini()` collecte tous les nœuds n'ayant qu'**une seule arête**.
+En l'absence de terminus (réseau en boucle), le premier nœud du graphe est
+utilisé comme point de départ.
+
+Chaque terminus lance un BFS indépendant (`runBFS()`), avec un `offsetX`
+croissant pour éviter les collisions entre composantes connexes distinctes.
+
+### Règles de positionnement
+
+Pour chaque nœud courant `(x, y)` et chaque voisin non encore visité :
+
+| Condition | Position voisin | `arrivedViaDeviation` |
+|-----------|-----------------|----------------------|
+| STRAIGHT / ROOT / NORMAL standard | `(x+1, y)` | `false` |
+| DEVIATION → straight ou switch ordinaire | `(x+1, y ± side)` | `false` |
+| DEVIATION → switch (double aiguille) | `(x, y ± side)` | `true` |
+| ROOT forward, arrivée via déviation | `(x+1, y)` | `false` |
+| NORMAL forward, arrivée via déviation | `(x-1, y)` | `false` |
+
+Le drapeau `arrivedViaDeviation` modifie le tri des voisins à la prochaine
+itération : ROOT est traité en premier (continuation de la route déviée).
+
+### Résolution de collision
+
+Quand deux nœuds obtiendraient la même position `(x, y)`, le nœud entrant
+est décalé verticalement par incrément de ±1 jusqu'à trouver une cellule
+libre. Cette résolution n'intervient que dans des topologies exceptionnelles.
+
+---
+
+## Rendu TCO — TCORenderer {#pcc_renderer}
+
+### Projection logique → écran
+
+La structure @ref TCORenderer::Projection est calculée une seule fois par
+`computeProjection()` et mise en cache dans `PCCPanel`. Elle contient :
+
+- `originX`, `originY` — décalage en pixels pour centrer le schéma
+- `scaleX`, `scaleY` — facteur d'échelle pixels/unité logique
+- `stub`, `inactiveGap`, `halfGap` — précalculs des constantes de dessin
+  des aiguillages (optimisation Famille E)
+
+```cpp
+POINT project(int logicalX, int logicalY, const Projection& proj)
+{
+    return { proj.originX + logicalX * proj.scaleX,
+             proj.originY + logicalY * proj.scaleY };
+}
+```
+
+### Rendu d'un StraightBlock
+
+`drawStraightBlock()` trace un **trait horizontal** avec un gap central
+(`BLOCK_GAP_PX`) représentant la section de voie. La couleur dépend de
+`ShuntingState` :
+
+| État | Couleur |
+|------|---------|
+| `FREE` | Gris clair `RGB(220,220,220)` |
+| `OCCUPIED` | Rouge `RGB(220,50,50)` |
+| `INACTIVE` | Gris foncé `RGB(80,80,80)` |
+
+### Rendu d'un SwitchBlock
+
+`drawSwitchBlock()` trace le symbole aiguille **junctionX** (forme Y) :
+
+- **Stub root** : trait depuis la position du switch vers la gauche (`stub`)
+- **Branche normale** : trait horizontal vers la droite
+- **Branche déviée** : trait oblique vers `(x+1, y ± deviationSide)`
+
+La branche inactive est tracée en gris atténué (`branchOff` `RGB(64,64,64)`).
+Chaque branche utilise un `PenScope` RAII indépendant (Famille D) — aucun
+`CreatePen` redondant, aucune fuite GDI.
+
+Le `static_cast<PCCSwitchNode*>` est garanti sûr par la vérification
+préalable de `getNodeType() == SWITCH` (Famille C — RTTI supprimé).
+
+---
+
+## PCCPanel — intégration Win32 {#pcc_panel}
+
+@ref PCCPanel est une fenêtre Win32 enfant de `MainWindow`. Elle gère :
+
+### Rebuild
+
+`rebuild()` est appelé après chaque parsing réussi. Il enchaîne :
+1. `PCCGraphBuilder::build()` — construit le graphe PCC
+2. `PCCLayout::compute()` — attribue les positions
+3. Invalide le cache de projection (`m_projDirty = true`)
+4. Déclenche `InvalidateRect()` pour forcer un `WM_PAINT`
+
+### Cache de projection (Famille F)
+
+La projection est coûteuse à recalculer. `PCCPanel` la met en cache dans
+`m_cachedProj` et ne la recalcule que si :
+- `m_projDirty == true` (après un rebuild), ou
+- la taille du client `RECT` a changé (resize fenêtre).
+
+`TCORenderer::draw()` reçoit la projection précalculée — il n'appelle plus
+`computeProjection()` en interne.
+
+### Navigation — zoom et pan
+
+- **Molette + Ctrl** → zoom centré sur la position curseur
+- **Cliquer-glisser** → pan (pan offset stocké dans `m_panX/Y`)
+- **Double-clic** → reset zoom = 1, pan = (0, 0)
+
+Le zoom/pan est appliqué via une **world transform GDI** (`SetWorldTransform`)
+avant l'appel à `TCORenderer::draw()`, avec `fillBackground = false` pour
+éviter de recouvrir la zone déjà peinte.
+
+---
+
+## Références croisées {#pcc_refs}
+
+| Classe | Fichier | Rôle |
+|--------|---------|------|
+| @ref PCCGraph | `Modules/PCC/PCCGraph.h` | Conteneur nœuds + arêtes |
+| @ref PCCNode | `Modules/PCC/PCCNode.h` | Nœud abstrait |
+| @ref PCCStraightNode | `Modules/PCC/PCCStraightNode.h` | Nœud straight concret |
+| @ref PCCSwitchNode | `Modules/PCC/PCCSwitchNode.h` | Nœud switch + deviationSide |
+| @ref PCCEdge | `Modules/PCC/PCCEdge.h` | Arête orientée avec rôle |
+| @ref PCCEdgeRole | `Modules/PCC/PCCEdge.h` | ROOT/NORMAL/DEVIATION/STRAIGHT |
+| @ref PCCNodeType | `Modules/PCC/PCCNode.h` | STRAIGHT/SWITCH |
+| @ref PCCGraphBuilder | `Modules/PCC/PCCGraphBuilder.h` | Construction graphe (3 passes) |
+| @ref PCCLayout | `Modules/PCC/PCCLayout.h` | Positionnement BFS |
+| @ref TCORenderer | `Engine/HMI/PCCPanel/TCORenderer.h` | Rendu GDI |
+| @ref TCORenderer::Projection | `Engine/HMI/PCCPanel/TCORenderer.h` | Cache de projection |
+| @ref PCCPanel | `Engine/HMI/PCCPanel/PCCPanel.h` | Fenêtre Win32 PCC |


### PR DESCRIPTION
## Summary
- Refonte des pages Doxygen existantes : `engine`, `geoparser`, `mainpage`, `pcc`
- Ajout de deux nouvelles pages : `hmi` et `interactiveElements`

## Test plan
- [ ] Vérifier que la génération Doxygen ne produit pas d'erreurs
- [ ] Contrôler le rendu des pages dans la documentation générée

🤖 Generated with [Claude Code](https://claude.com/claude-code)